### PR TITLE
Sprint1/add input

### DIFF
--- a/lib/Board.ex
+++ b/lib/Board.ex
@@ -21,6 +21,14 @@ defmodule Board do
   end
 
   @doc """
+  Recieves a board and a position and returns a bool indicating if the requested position is available
+  """
+  def available?(board, position) do
+    {:ok, mark} = Map.fetch(board, position)
+    mark == ""
+  end
+
+  @doc """
   Recieves a board state and determines if any winning combinations exist
   """
   def hasWon?(board) do

--- a/lib/UI.ex
+++ b/lib/UI.ex
@@ -9,6 +9,15 @@ defmodule UI do
     print_header(io)
   end
 
+  def message(key) do
+    case key do
+      :nan -> "Sorry, that's not a valid number. Please enter a whole number."
+      :out_of_bounds -> "Sorry, that number isn't available on the board."
+      :occupied -> "Sorry, that square has been taken. Please enter an unoccupied square."
+      _ -> "Uh-oh, something went wrong!"
+    end
+  end
+
   def print_winner(mark, io \\ :stdio) do
     out("Player #{mark} wins!", io)
   end

--- a/lib/io.ex
+++ b/lib/io.ex
@@ -1,8 +1,8 @@
 defmodule TicTacToe.Io do
   def get_position(io \\ :stdio) do
-    input = input(io)
-
-    case Integer.parse(input) do
+    input(io)
+    |> Integer.parse()
+    |> case do
       {int, _} -> computerise(int)
       _ -> get_position(io)
     end

--- a/lib/io.ex
+++ b/lib/io.ex
@@ -1,0 +1,19 @@
+defmodule TicTacToe.Io do
+  def get_position(io \\ :stdio, msg \\ "") do
+    input = input(io, msg)
+    error = "That input is invalid. Please enter a valid input."
+
+    case Integer.parse(input) do
+      {int, _} -> computerise(int)
+      _ -> get_position(io, error)
+    end
+  end
+
+  defp computerise(position) do
+    position - 1
+  end
+
+  defp input(io, msg) do
+    IO.gets(io, msg)
+  end
+end

--- a/lib/io.ex
+++ b/lib/io.ex
@@ -1,11 +1,10 @@
 defmodule TicTacToe.Io do
-  def get_position(io \\ :stdio, msg \\ "") do
-    input = input(io, msg)
-    error = "That input is invalid. Please enter a valid input."
+  def get_position(io \\ :stdio) do
+    input = input(io)
 
     case Integer.parse(input) do
       {int, _} -> computerise(int)
-      _ -> get_position(io, error)
+      _ -> get_position(io)
     end
   end
 
@@ -13,7 +12,7 @@ defmodule TicTacToe.Io do
     position - 1
   end
 
-  defp input(io, msg) do
-    IO.gets(io, msg)
+  defp input(io) do
+    IO.gets(io, "")
   end
 end

--- a/lib/io.ex
+++ b/lib/io.ex
@@ -15,4 +15,8 @@ defmodule TicTacToe.Io do
   defp input(io) do
     IO.gets(io, "")
   end
+
+  def output(io, contents) do
+    IO.write(io, contents)
+  end
 end

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -1,5 +1,17 @@
 defmodule PlayerHuman do
-  def valid_move?(position, board) do
-    {:ok, 1}
+  def valid_move?(position, _board, _args) when not is_integer(position) do
+    {:error, :nan}
+  end
+
+  def valid_move?(position, _board, _args) when position < 0 or position > 8 do
+    {:error, :out_of_bounds}
+  end
+
+  def valid_move?(position, board, args) do
+    if args.board.available?(board, position) do
+      {:ok, position}
+    else
+      {:error, :occupied}
+    end
   end
 end

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -16,7 +16,7 @@ defmodule PlayerHuman do
   end
 
   def valid_move?(position, _board, _args)
-      when @first_square or position > @last_square do
+      when position < @first_square or position > @last_square do
     {:error, :out_of_bounds}
   end
 

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -1,0 +1,5 @@
+defmodule PlayerHuman do
+  def valid_move?(position, board) do
+    {:ok, 1}
+  end
+end

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -3,10 +3,11 @@ defmodule PlayerHuman do
   @last_square 8
   def move(board, message, args, io \\ :stdio) do
     args.io.output(io, message)
-    position = args.io.get_position(io)
 
-    case valid_move?(position, board, args) do
-      {:ok, _} -> position
+    args.io.get_position(io)
+    |> valid_move?(board, args)
+    |> case do
+      {:ok, position} -> position
       {:error, message} -> move(board, args.ui.message(message), args)
     end
   end

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -1,8 +1,11 @@
 defmodule PlayerHuman do
-  def move(position, board, args) do
+  def move(board, message, args, io \\ :stdio) do
+    args.io.output(io, message)
+    position = args.io.get_position(io)
+
     case valid_move?(position, board, args) do
-      {:ok, move} -> move
-      {:error, :message} -> :message
+      {:ok, _move} -> args.board.update(board, position, args.mark)
+      {:error, message} -> move(board, args.ui.message(message), args)
     end
   end
 

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -4,7 +4,7 @@ defmodule PlayerHuman do
     position = args.io.get_position(io)
 
     case valid_move?(position, board, args) do
-      {:ok, _move} -> args.board.update(board, position, args.mark)
+      {:ok, _} -> position
       {:error, message} -> move(board, args.ui.message(message), args)
     end
   end

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -1,4 +1,6 @@
 defmodule PlayerHuman do
+  @first_square 0
+  @last_square 8
   def move(board, message, args, io \\ :stdio) do
     args.io.output(io, message)
     position = args.io.get_position(io)
@@ -13,7 +15,8 @@ defmodule PlayerHuman do
     {:error, :nan}
   end
 
-  def valid_move?(position, _board, _args) when position < 0 or position > 8 do
+  def valid_move?(position, _board, _args)
+      when @first_square or position > @last_square do
     {:error, :out_of_bounds}
   end
 

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -1,4 +1,11 @@
 defmodule PlayerHuman do
+  def move(position, board, args) do
+    case valid_move?(position, board, args) do
+      {:ok, move} -> move
+      {:error, :message} -> :message
+    end
+  end
+
   def valid_move?(position, _board, _args) when not is_integer(position) do
     {:error, :nan}
   end

--- a/test/io_test.exs
+++ b/test/io_test.exs
@@ -1,0 +1,13 @@
+defmodule IOTest do
+  use ExUnit.Case
+
+  test "get_position returns a zero-indexed number" do
+    {:ok, io} = StringIO.open("1")
+    assert TicTacToe.Io.get_position(io) == 0
+  end
+
+  test "get_position repeats until valid numerical input is provided" do
+    {:ok, io} = StringIO.open("cat1\n2")
+    assert TicTacToe.Io.get_position(io) == 1
+  end
+end

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -3,16 +3,14 @@ defmodule PlayerHumanTest do
   @board Board.new()
   @args %{board: Board, io: TicTacToe.Io, ui: UI, mark: "X"}
 
-  test "move/4 can get a valid move from the user and return a new board state" do
+  test "move/4 can get a valid move from the user and return the zero-indexed integer" do
     {:ok, io} = StringIO.open("1")
-    %{0 => mark} = PlayerHuman.move(@board, "", @args, io)
-    assert mark == "X"
+    assert PlayerHuman.move(@board, "", @args, io) == 0
   end
 
   test "move/4 will prompt again if user does not submit valid move" do
     {:ok, io} = StringIO.open("cat\n1")
-    %{0 => mark} = PlayerHuman.move(@board, "", @args, io)
-    assert mark == "X"
+    assert PlayerHuman.move(@board, "", @args, io) == 0
   end
 
   test "valid_move?/3 returns :ok when placing valid move on an empty board" do

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -1,9 +1,27 @@
 defmodule PlayerHumanTest do
   use ExUnit.Case
+  @board Board.new()
+  @args %{board: Board}
 
   test "can place a move on an empty board" do
     position = 1
-    board = %{0 => nil, 1 => nil}
-    assert PlayerHuman.valid_move?(position, board) == {:ok, 1}
+    board = Board.new()
+    assert PlayerHuman.valid_move?(position, board, @args) == {:ok, 1}
+  end
+
+  test "returns :error if move is already taken" do
+    position = 2
+    board = Board.update(@board, position, "X")
+    assert PlayerHuman.valid_move?(position, board, @args) == {:error, :occupied}
+  end
+
+  test "returns {:error, :out_of_bounds} if position does not exist on board" do
+    position = 25
+    assert PlayerHuman.valid_move?(position, @board, @args) == {:error, :out_of_bounds}
+  end
+
+  test "returns {:error, :nan} if requested position is not an integer" do
+    position = "cat"
+    assert PlayerHuman.valid_move?(position, @board, @args) == {:error, :nan}
   end
 end

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -3,13 +3,13 @@ defmodule PlayerHumanTest do
   @board Board.new()
   @args %{board: Board, io: TicTacToe.Io, ui: UI, mark: "X"}
 
-  test "move/4 can get a valid move from the user" do
+  test "move/4 can get a valid move from the user and return a new board state" do
     {:ok, io} = StringIO.open("1")
     %{0 => mark} = PlayerHuman.move(@board, "", @args, io)
     assert mark == "X"
   end
 
-  test "move/4 will prompt again if user does not submit valid move " do
+  test "move/4 will prompt again if user does not submit valid move" do
     {:ok, io} = StringIO.open("cat\n1")
     %{0 => mark} = PlayerHuman.move(@board, "", @args, io)
     assert mark == "X"

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -1,0 +1,9 @@
+defmodule PlayerHumanTest do
+  use ExUnit.Case
+
+  test "can place a move on an empty board" do
+    position = 1
+    board = %{0 => nil, 1 => nil}
+    assert PlayerHuman.valid_move?(position, board) == {:ok, 1}
+  end
+end

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -1,26 +1,38 @@
 defmodule PlayerHumanTest do
   use ExUnit.Case
   @board Board.new()
-  @args %{board: Board}
+  @args %{board: Board, io: TicTacToe.Io, ui: UI, mark: "X"}
 
-  test "can place a move on an empty board" do
+  test "move/4 can get a valid move from the user" do
+    {:ok, io} = StringIO.open("1")
+    %{0 => mark} = PlayerHuman.move(@board, "", @args, io)
+    assert mark == "X"
+  end
+
+  test "move/4 will prompt again if user does not submit valid move " do
+    {:ok, io} = StringIO.open("cat\n1")
+    %{0 => mark} = PlayerHuman.move(@board, "", @args, io)
+    assert mark == "X"
+  end
+
+  test "valid_move?/3 returns :ok when placing valid move on an empty board" do
     position = 1
     board = Board.new()
     assert PlayerHuman.valid_move?(position, board, @args) == {:ok, 1}
   end
 
-  test "returns :error if move is already taken" do
+  test "valid_move?/3 returns {:error, :occupied} if move is already taken" do
     position = 2
     board = Board.update(@board, position, "X")
     assert PlayerHuman.valid_move?(position, board, @args) == {:error, :occupied}
   end
 
-  test "returns {:error, :out_of_bounds} if position does not exist on board" do
+  test "valid_move?/3 returns {:error, :out_of_bounds} if number too big/small" do
     position = 25
     assert PlayerHuman.valid_move?(position, @board, @args) == {:error, :out_of_bounds}
   end
 
-  test "returns {:error, :nan} if requested position is not an integer" do
+  test "valid_move?/3 returns {:error, :nan} if position is not an integer" do
     position = "cat"
     assert PlayerHuman.valid_move?(position, @board, @args) == {:error, :nan}
   end


### PR DESCRIPTION
This PR adds the `PlayerHuman` module which updates the board state based on valid input, with some error checking thrown into the mix. It communicates with both the UI and IO modules. 

Couple of extra notes: 

1) We're using `args.board` to represent the injected `Board` module, but this creates some confusion with capital-B module board and little-B board state - so I think it's worth course correcting the API there 
2) There is currently duplication between the `IO.output` and the `UI.out` functions - in a future PR I'll push everything to the former. I am not 100% convinced on the current setup of `UI` and think it needs some work. 