### PR TITLE
Sprint2/separate io from ui

### DIFF
--- a/lib/Board.ex
+++ b/lib/Board.ex
@@ -14,9 +14,16 @@ defmodule Board do
   Update an existing board in the specified position with a specified mark. Does not overwrite existing marks.
   """
   def update(board, pos, mark) do
-    case Map.fetch(board, pos) do
-      {:ok, square} when square == "" -> Map.put(board, pos, mark)
+    case get(board, pos) do
+      square when square == "" -> Map.put(board, pos, mark)
       _ -> board
+    end
+  end
+
+  def get(board, pos) do
+    case Map.fetch(board, pos) do
+      {:ok, square} -> square
+      _ -> :error
     end
   end
 
@@ -24,8 +31,10 @@ defmodule Board do
   Recieves a board and a position and returns a bool indicating if the requested position is available
   """
   def available?(board, position) do
-    {:ok, mark} = Map.fetch(board, position)
-    mark == ""
+    case get(board, position) do
+      :error -> :error
+      square -> square == ""
+    end
   end
 
   def available_positions(board) do

--- a/lib/Board.ex
+++ b/lib/Board.ex
@@ -1,4 +1,5 @@
 defmodule Board do
+  @empty_square ""
   @moduledoc """
   Contains functions to determine board management - creation, updating and determining if a player has filled a row, column or diagonal
   """
@@ -7,7 +8,7 @@ defmodule Board do
   Return an empty board
   """
   def new do
-    Enum.reduce(0..8, %{}, &Map.put(&2, &1, ""))
+    Enum.reduce(0..8, %{}, &Map.put(&2, &1, @empty_square))
   end
 
   @doc """
@@ -15,7 +16,7 @@ defmodule Board do
   """
   def update(board, pos, mark) do
     case get(board, pos) do
-      square when square == "" -> Map.put(board, pos, mark)
+      @empty_square -> Map.put(board, pos, mark)
       _ -> board
     end
   end
@@ -33,13 +34,13 @@ defmodule Board do
   def available?(board, position) do
     case get(board, position) do
       :error -> :error
-      square -> square == ""
+      square -> square == @empty_square
     end
   end
 
   def available_positions(board) do
     board
-    |> Enum.filter(fn {_, occupant} -> occupant == "" end)
+    |> Enum.filter(fn {_, occupant} -> occupant == @empty_square end)
     |> Enum.map(fn {position, _} -> position end)
   end
 
@@ -53,7 +54,7 @@ defmodule Board do
 
   def moves?(board) do
     board
-    |> Enum.filter(fn {_, occupant} -> occupant == "" end)
+    |> Enum.filter(fn {_, occupant} -> occupant == @empty_square end)
     |> case do
       [] -> :no_moves
       moves -> Enum.count(moves)
@@ -80,7 +81,8 @@ defmodule Board do
         Map.take(board, x)
         |> Map.values()
 
-      Enum.count(values) == 3 && hd(values) != "" && Enum.all?(values, &(&1 == hd(values)))
+      Enum.count(values) == 3 && hd(values) != @empty_square &&
+        Enum.all?(values, &(&1 == hd(values)))
     end)
   end
 end

--- a/lib/UI.ex
+++ b/lib/UI.ex
@@ -1,5 +1,5 @@
 defmodule UI do
-  def print_board_string(board) do
+  def draw_board(board) do
     [
       header(),
       row(board, 0..2),
@@ -11,10 +11,6 @@ defmodule UI do
       ""
     ]
     |> Enum.join("\n")
-  end
-
-  def print_board(state, io \\ :stdio) do
-    out(print_board_string(state), io)
   end
 
   defp header(), do: "+-----------+"
@@ -56,24 +52,20 @@ defmodule UI do
     end
   end
 
-  def print_winner(mark, io \\ :stdio) do
-    out("Player #{mark} wins!\n", io)
+  def winner(mark) do
+    "Player #{mark} wins!"
   end
 
-  def print_turn(mark, io \\ :stdio) do
-    out("Player #{mark}'s turn:\n", io)
+  def player_turn(mark) do
+    "Player #{mark}'s turn:"
   end
 
-  def print_draw(io \\ :stdio) do
-    out("It's a draw!\n", io)
+  def draw() do
+    "It's a draw!"
   end
 
-  def print_instructions(io \\ :stdio) do
-    out("Input numbers between 1-9 on alternative turns to place your mark in the 3x3 grid.", io)
-  end
-
-  defp out(contents, io) do
-    IO.write(io, contents)
+  def instructions() do
+    "Input numbers between 1-9 on alternative turns to place your mark in the 3x3 grid."
   end
 
   defp fade(text) do

--- a/lib/UI.ex
+++ b/lib/UI.ex
@@ -33,10 +33,10 @@ defmodule UI do
   def message(key) do
     case key do
       :title ->
-        "TIC TAC TOE\n"
+        "TIC TAC TOE"
 
       :intro ->
-        "Turn friends into enemies by succeeding in placing a complete line in any horizontal, vertical or diagonal direction\n"
+        "Turn friends into enemies by succeeding in placing a complete line in any horizontal, vertical or diagonal direction"
 
       :nan ->
         "Sorry, that's not a valid number. Please enter a whole number."
@@ -57,7 +57,7 @@ defmodule UI do
   end
 
   def player_turn(mark) do
-    "Player #{mark}'s turn:"
+    "Player #{mark}'s turn: "
   end
 
   def draw() do

--- a/lib/UI.ex
+++ b/lib/UI.ex
@@ -1,12 +1,37 @@
 defmodule UI do
+  def print_board_string(board) do
+    [
+      header(),
+      row(board, 0..2),
+      header(),
+      row(board, 3..5),
+      header(),
+      row(board, 6..8),
+      header(),
+      ""
+    ]
+    |> Enum.join("\n")
+  end
+
   def print_board(state, io \\ :stdio) do
-    print_header(io)
-    print_row(state, 0..2, io)
-    print_header(io)
-    print_row(state, 3..5, io)
-    print_header(io)
-    print_row(state, 6..8, io)
-    print_header(io)
+    out(print_board_string(state), io)
+  end
+
+  defp header(), do: "+-----------+"
+
+  defp row(board, range) do
+    Enum.reduce(range, "", fn pos, acc -> acc <> square(board, pos) end) <> "|"
+  end
+
+  defp square(board, position) do
+    square =
+      Board.get(board, position)
+      |> case do
+        "" -> humanise(position) |> fade()
+        mark -> mark
+      end
+
+    "| #{square} "
   end
 
   def message(key) do
@@ -45,26 +70,6 @@ defmodule UI do
 
   def print_instructions(io \\ :stdio) do
     out("Input numbers between 1-9 on alternative turns to place your mark in the 3x3 grid.", io)
-  end
-
-  defp print_header(io) do
-    out("+-----------+\n", io)
-  end
-
-  defp print_row(state, range, io) do
-    Enum.each(range, fn pos -> print_square(state, pos, io) end)
-    out("|\n", io)
-  end
-
-  defp print_square(state, position, io) do
-    square =
-      Map.get(state, position)
-      |> case do
-        "" -> humanise(position) |> fade()
-        mark -> mark
-      end
-
-    out("| #{square} ", io)
   end
 
   defp out(contents, io) do

--- a/lib/io.ex
+++ b/lib/io.ex
@@ -16,6 +16,10 @@ defmodule TicTacToe.Io do
     IO.gets(io, "")
   end
 
+  def output(io, contents) when is_list(contents) do
+    IO.write(io, Enum.join(contents, "\n") <> "\n")
+  end
+
   def output(io, contents) do
     IO.write(io, contents)
   end

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -14,31 +14,34 @@ defmodule TicTacToe do
         },
         device \\ :stdio
       ) do
+    out = fn message -> io.output(device, message) end
     game_board = board.new()
     players = Enum.zip([@player_cross, @player_nought], players)
-    out(ui.message(:title), io, device)
-    out(ui.message(:intro), io, device)
+    out.(ui.message(:title))
+    out.(ui.message(:intro))
 
     tick(:active, players, %{
       board: board,
       game_board: game_board,
+      out: out,
       io: io,
-      ui: ui,
-      device: device
+      device: device,
+      ui: ui
     })
   end
 
   defp tick(:active, players, %{
          board: board,
          game_board: game_board,
-         io: io,
          ui: ui,
-         device: device
+         io: io,
+         device: device,
+         out: out
        }) do
     {current_mark, current_player} = List.first(players)
     {opponent_mark, _} = List.last(players)
-    out(ui.draw_board(game_board), io, device)
-    out(ui.player_turn(current_mark), io, device)
+    out.(ui.draw_board(game_board))
+    out.(ui.player_turn(current_mark))
 
     pos =
       current_player.move(
@@ -58,11 +61,12 @@ defmodule TicTacToe do
           io: io,
           device: device,
           ui: ui,
+          out: out,
           mark: current_mark
         })
 
       :drawn ->
-        tick(:drawn, %{game_board: updated_board, io: io, device: device, ui: ui})
+        tick(:drawn, %{game_board: updated_board, out: out, ui: ui})
 
       :active ->
         tick(:active, Enum.reverse(players), %{
@@ -70,22 +74,19 @@ defmodule TicTacToe do
           game_board: updated_board,
           io: io,
           ui: ui,
+          out: out,
           device: device
         })
     end
   end
 
-  defp tick(:drawn, %{game_board: game_board, ui: ui, io: io, device: device}) do
-    out(ui.draw_board(game_board), io, device)
-    out(ui.draw(), io, device)
+  defp tick(:drawn, %{game_board: game_board, ui: ui, out: out}) do
+    out.(ui.draw_board(game_board))
+    out.(ui.draw())
   end
 
-  defp tick(:won, %{game_board: game_board, ui: ui, io: io, device: device, mark: mark}) do
-    out(ui.draw_board(game_board), io, device)
-    out(ui.winner(mark), io, device)
-  end
-
-  defp out(message, io, device) do
-    io.output(device, message)
+  defp tick(:won, %{game_board: game_board, out: out, ui: ui, mark: mark}) do
+    out.(ui.draw_board(game_board))
+    out.(ui.winner(mark))
   end
 end

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -37,7 +37,7 @@ defmodule TicTacToe do
        }) do
     {current_mark, current_player} = List.first(players)
     {opponent_mark, _} = List.last(players)
-    print_board(game_board, ui, io, device)
+    out(ui.draw_board(game_board), io, device)
     out(ui.player_turn(current_mark), io, device)
 
     pos =
@@ -76,17 +76,13 @@ defmodule TicTacToe do
   end
 
   defp tick(:drawn, %{game_board: game_board, ui: ui, io: io, device: device}) do
-    print_board(game_board, ui, io, device)
+    out(ui.draw_board(game_board), io, device)
     out(ui.draw(), io, device)
   end
 
   defp tick(:won, %{game_board: game_board, ui: ui, io: io, device: device, mark: mark}) do
-    print_board(game_board, ui, io, device)
+    out(ui.draw_board(game_board), io, device)
     out(ui.winner(mark), io, device)
-  end
-
-  defp print_board(board, ui, io, device) do
-    out(ui.draw_board(board), io, device)
   end
 
   defp out(message, io, device) do

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -17,8 +17,9 @@ defmodule TicTacToe do
     out = fn message -> io.output(device, message) end
     game_board = board.new()
     players = Enum.zip([@player_cross, @player_nought], players)
-    out.(ui.message(:title))
-    out.(ui.message(:intro))
+
+    [ui.message(:title), ui.message(:intro)]
+    |> out.()
 
     tick(:active, players, %{
       board: board,
@@ -40,8 +41,9 @@ defmodule TicTacToe do
        }) do
     {current_mark, current_player} = List.first(players)
     {opponent_mark, _} = List.last(players)
-    out.(ui.draw_board(game_board))
-    out.(ui.player_turn(current_mark))
+
+    [ui.draw_board(game_board), ui.player_turn(current_mark)]
+    |> out.()
 
     pos =
       current_player.move(
@@ -81,12 +83,12 @@ defmodule TicTacToe do
   end
 
   defp tick(:drawn, %{game_board: game_board, ui: ui, out: out}) do
-    out.(ui.draw_board(game_board))
-    out.(ui.draw())
+    [ui.draw_board(game_board), ui.draw()]
+    |> out.()
   end
 
   defp tick(:won, %{game_board: game_board, out: out, ui: ui, mark: mark}) do
-    out.(ui.draw_board(game_board))
-    out.(ui.winner(mark))
+    [ui.draw_board(game_board), ui.winner(mark)]
+    |> out.()
   end
 end

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -16,8 +16,8 @@ defmodule TicTacToe do
       ) do
     game_board = board.new()
     players = Enum.zip([@player_cross, @player_nought], players)
-    out(ui.message(:title), io)
-    out(ui.message(:intro), io)
+    out(ui.message(:title), io, device)
+    out(ui.message(:intro), io, device)
 
     tick(:active, players, %{
       board: board,
@@ -37,8 +37,8 @@ defmodule TicTacToe do
        }) do
     {current_mark, current_player} = List.first(players)
     {opponent_mark, _} = List.last(players)
-    print_board(game_board, ui)
-    ui.print_turn(current_mark)
+    print_board(game_board, ui, io, device)
+    out(ui.player_turn(current_mark), io, device)
 
     pos =
       current_player.move(
@@ -53,10 +53,16 @@ defmodule TicTacToe do
     board.status(updated_board)
     |> case do
       :won ->
-        tick(:won, %{game_board: updated_board, ui: ui, mark: current_mark})
+        tick(:won, %{
+          game_board: updated_board,
+          io: io,
+          device: device,
+          ui: ui,
+          mark: current_mark
+        })
 
       :drawn ->
-        tick(:drawn, %{game_board: updated_board, ui: ui})
+        tick(:drawn, %{game_board: updated_board, io: io, device: device, ui: ui})
 
       :active ->
         tick(:active, Enum.reverse(players), %{
@@ -69,21 +75,21 @@ defmodule TicTacToe do
     end
   end
 
-  defp tick(:drawn, %{game_board: game_board, ui: ui}) do
-    print_board(game_board, ui)
-    ui.print_draw()
+  defp tick(:drawn, %{game_board: game_board, ui: ui, io: io, device: device}) do
+    print_board(game_board, ui, io, device)
+    out(ui.draw(), io, device)
   end
 
-  defp tick(:won, %{game_board: game_board, ui: ui, mark: mark}) do
-    print_board(game_board, ui)
-    ui.print_winner(mark)
+  defp tick(:won, %{game_board: game_board, ui: ui, io: io, device: device, mark: mark}) do
+    print_board(game_board, ui, io, device)
+    out(ui.winner(mark), io, device)
   end
 
-  defp print_board(board, ui, device \\ :stdio) do
-    ui.print_board(board, device)
+  defp print_board(board, ui, io, device) do
+    out(ui.draw_board(board), io, device)
   end
 
-  defp out(message, io, device \\ :stdio) do
+  defp out(message, io, device) do
     io.output(device, message)
   end
 end

--- a/test/UI_test.exs
+++ b/test/UI_test.exs
@@ -21,4 +21,21 @@ defmodule UITest do
     assert StringIO.flush(io) ==
              "+-----------+\n| X | O | O |\n+-----------+\n| O | X | X |\n+-----------+\n| X | X | O |\n+-----------+\n"
   end
+
+  test "UI.show_board_string/1 should output current game state" do
+    board =
+      Board.new()
+      |> Board.update(0, "X")
+      |> Board.update(1, "O")
+      |> Board.update(2, "O")
+      |> Board.update(3, "O")
+      |> Board.update(4, "X")
+      |> Board.update(5, "X")
+      |> Board.update(6, "X")
+      |> Board.update(7, "X")
+      |> Board.update(8, "O")
+
+    assert UI.print_board_string(board) ==
+             "+-----------+\n| X | O | O |\n+-----------+\n| O | X | X |\n+-----------+\n| X | X | O |\n+-----------+\n"
+  end
 end

--- a/test/UI_test.exs
+++ b/test/UI_test.exs
@@ -1,28 +1,7 @@
 defmodule UITest do
   use ExUnit.Case
 
-  # TODO replace with Board.new() API when implemented
-  @board %{
-    0 => "X",
-    1 => "O",
-    2 => "O",
-    3 => "O",
-    4 => "X",
-    5 => "X",
-    6 => "X",
-    7 => "X",
-    8 => "O"
-  }
-
-  test "UI.show_board/2 should output current game state" do
-    {:ok, io} = StringIO.open("")
-    UI.print_board(@board, io)
-
-    assert StringIO.flush(io) ==
-             "+-----------+\n| X | O | O |\n+-----------+\n| O | X | X |\n+-----------+\n| X | X | O |\n+-----------+\n"
-  end
-
-  test "UI.show_board_string/1 should output current game state" do
+  test "UI.draw_board/1 should output current game state" do
     board =
       Board.new()
       |> Board.update(0, "X")
@@ -35,7 +14,7 @@ defmodule UITest do
       |> Board.update(7, "X")
       |> Board.update(8, "O")
 
-    assert UI.print_board_string(board) ==
+    assert UI.draw_board(board) ==
              "+-----------+\n| X | O | O |\n+-----------+\n| O | X | X |\n+-----------+\n| X | X | O |\n+-----------+\n"
   end
 end


### PR DESCRIPTION
This PR (attempts) to separate out the IO from the UI... 

- My intention: remove IO from `PlayerHuman`, so we're sticking with a nice functional core and consolidating all the pesky side effects elsewhere. But what is the purpose of `PlayerHuman` without IO, and how would we juggle that with the fact that `PlayerMinimax` also needs to operate with the same signature? The basic idea is that they both return an integer of the position on the board they want to move on. But I can't figure out an elegant way to get that working. 
- a wrapped function, `out`, currently is defined in `TicTacToe` which combines `IO` and `device` - the idea is that we only need to pass `out` (and potentially an `input`) down as our args, rather than all the `io`, `ui,` and `device`. But the first point kind of makes this a moot situation right now, as `PlayerHuman` requires all of these things. 
- `Board` has a new function, `get/2`, which returns the contents of a particular square. This is for the benefit of `UI`, which does not need to access the underlying data structure anymore. It's also used internally within `Board`. 

Notes:
- `pos` is a bad variable name but it's common in the codebase, I intend to create another PR to change this. 
- 'TicTacToe` is still very messy and a thorny web of dependencies - this will be the subject of another PR that this builds upon. The idea is to build a struct `Game` with required fields in `CLI` and pass that down to `TicTacToe` and not destructure it in the function signature. But I'm hoping to tidy up the IO/UI first. 
