### PR TITLE
Sprint2/refactoring

### DIFF
--- a/lib/args.ex
+++ b/lib/args.ex
@@ -12,6 +12,13 @@ defmodule GameState do
     }
   end
 
+  def new(board, player_mode) do
+    %GameState{
+      board: board,
+      players: Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(player_mode))
+    }
+  end
+
   def update_board(game, new_board) do
     %GameState{game | board: new_board}
   end

--- a/lib/args.ex
+++ b/lib/args.ex
@@ -1,39 +1,3 @@
-defmodule DisplayState do
-  defstruct [:io, :device, :ui, :in, :out]
-
-  def new(io, ui, device) do
-    %DisplayState{
-      ui: ui,
-      in: fn -> io.get_position(device) end,
-      out: fn message -> io.output(device, message) end
-    }
-  end
-end
-
-defmodule GameState do
-  @player_cross "X"
-  @player_nought "O"
-  defstruct [:board, :players]
-
-  alias TicTacToe.Players
-
-  def new(player_mode, opts) do
-    %GameState{
-      board: Board.new(),
-      players:
-        Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(player_mode, opts))
-    }
-  end
-
-  def update_board(game, new_board) do
-    %GameState{game | board: new_board}
-  end
-
-  def update_players(game) do
-    %GameState{game | players: Players.next_turn(game.players)}
-  end
-end
-
 defmodule Args do
   defstruct [:game, :display]
 

--- a/lib/args.ex
+++ b/lib/args.ex
@@ -17,24 +17,11 @@ defmodule GameState do
 
   alias TicTacToe.Players
 
-  def new(players) when is_list(players) do
+  def new(player_mode, opts) do
     %GameState{
       board: Board.new(),
-      players: players
-    }
-  end
-
-  def new(player_mode) do
-    %GameState{
-      board: Board.new(),
-      players: Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(player_mode))
-    }
-  end
-
-  def new(board, player_mode) do
-    %GameState{
-      board: board,
-      players: Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(player_mode))
+      players:
+        Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(player_mode, opts))
     }
   end
 
@@ -50,17 +37,12 @@ end
 defmodule Args do
   defstruct [:game, :display]
 
-  def new(%DisplayState{} = display, %GameState{} = game) do
-    %Args{
-      game: game,
-      display: display
-    }
-  end
-
   def new(mode, device \\ :stdio) do
+    display = DisplayState.new(TicTacToe.Io, UI, device)
+
     %Args{
-      game: GameState.new(mode),
-      display: DisplayState.new(TicTacToe.Io, UI, device)
+      game: GameState.new(mode, display),
+      display: display
     }
   end
 

--- a/lib/args.ex
+++ b/lib/args.ex
@@ -1,11 +1,11 @@
-defmodule Game do
+defmodule Args do
   @enforce_keys [:board, :board_manager, :ui, :out, :in, :players]
   defstruct [:board_manager, :board, :ui, :in, :out, :players]
   @player_cross "X"
   @player_nought "O"
 
   def new(mode, device \\ :stdio) do
-    %Game{
+    %Args{
       board_manager: Board,
       board: Board.new(),
       ui: UI,

--- a/lib/args.ex
+++ b/lib/args.ex
@@ -1,4 +1,6 @@
 defmodule Args do
+  alias TicTacToe.Players, as: Players
+
   @enforce_keys [:board, :board_manager, :ui, :out, :in, :players]
   defstruct [:board_manager, :board, :ui, :in, :out, :players]
   @player_cross "X"
@@ -13,5 +15,13 @@ defmodule Args do
       out: fn message -> TicTacToe.Io.output(device, message) end,
       players: Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(mode))
     }
+  end
+
+  def update_board(args, new_board) do
+    %Args{args | board: new_board}
+  end
+
+  def update_players(args) do
+    %Args{args | players: Players.next_turn(args.players)}
   end
 end

--- a/lib/args.ex
+++ b/lib/args.ex
@@ -1,14 +1,13 @@
 defmodule Args do
   alias TicTacToe.Players, as: Players
 
-  @enforce_keys [:board, :board_manager, :ui, :out, :in, :players]
-  defstruct [:board_manager, :board, :ui, :in, :out, :players]
+  @enforce_keys [:board, :ui, :out, :in, :players]
+  defstruct [:board, :ui, :in, :out, :players]
   @player_cross "X"
   @player_nought "O"
 
   def new(mode, device \\ :stdio) do
     %Args{
-      board_manager: Board,
       board: Board.new(),
       ui: UI,
       in: fn -> TicTacToe.Io.get_position(device) end,

--- a/lib/args.ex
+++ b/lib/args.ex
@@ -3,9 +3,7 @@ defmodule DisplayState do
 
   def new(io, ui, device) do
     %DisplayState{
-      io: io,
       ui: ui,
-      device: device,
       in: fn -> io.get_position(device) end,
       out: fn message -> io.output(device, message) end
     }

--- a/lib/args.ex
+++ b/lib/args.ex
@@ -17,6 +17,13 @@ defmodule GameState do
 
   alias TicTacToe.Players
 
+  def new(players) when is_list(players) do
+    %GameState{
+      board: Board.new(),
+      players: players
+    }
+  end
+
   def new(player_mode) do
     %GameState{
       board: Board.new(),
@@ -42,6 +49,13 @@ end
 
 defmodule Args do
   defstruct [:game, :display]
+
+  def new(%DisplayState{} = display, %GameState{} = game) do
+    %Args{
+      game: game,
+      display: display
+    }
+  end
 
   def new(mode, device \\ :stdio) do
     %Args{

--- a/lib/args.ex
+++ b/lib/args.ex
@@ -1,26 +1,43 @@
-defmodule Args do
-  alias TicTacToe.Players, as: Players
-
-  @enforce_keys [:board, :ui, :out, :in, :players]
-  defstruct [:board, :ui, :in, :out, :players]
+defmodule GameState do
   @player_cross "X"
   @player_nought "O"
+  defstruct [:board, :players]
+
+  alias TicTacToe.Players
+
+  def new(player_mode) do
+    %GameState{
+      board: Board.new(),
+      players: Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(player_mode))
+    }
+  end
+
+  def update_board(game, new_board) do
+    %GameState{game | board: new_board}
+  end
+
+  def update_players(game) do
+    %GameState{game | players: Players.next_turn(game.players)}
+  end
+end
+
+defmodule Args do
+  defstruct [:game, :ui, :in, :out]
 
   def new(mode, device \\ :stdio) do
     %Args{
-      board: Board.new(),
+      game: GameState.new(mode),
       ui: UI,
       in: fn -> TicTacToe.Io.get_position(device) end,
-      out: fn message -> TicTacToe.Io.output(device, message) end,
-      players: Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(mode))
+      out: fn message -> TicTacToe.Io.output(device, message) end
     }
   end
 
   def update_board(args, new_board) do
-    %Args{args | board: new_board}
+    %Args{args | game: GameState.update_board(args.game, new_board)}
   end
 
   def update_players(args) do
-    %Args{args | players: Players.next_turn(args.players)}
+    %Args{args | game: GameState.update_players(args.game)}
   end
 end

--- a/lib/args.ex
+++ b/lib/args.ex
@@ -1,3 +1,17 @@
+defmodule DisplayState do
+  defstruct [:io, :device, :ui, :in, :out]
+
+  def new(io, ui, device) do
+    %DisplayState{
+      io: io,
+      ui: ui,
+      device: device,
+      in: fn -> io.get_position(device) end,
+      out: fn message -> io.output(device, message) end
+    }
+  end
+end
+
 defmodule GameState do
   @player_cross "X"
   @player_nought "O"
@@ -29,14 +43,12 @@ defmodule GameState do
 end
 
 defmodule Args do
-  defstruct [:game, :ui, :in, :out]
+  defstruct [:game, :display]
 
   def new(mode, device \\ :stdio) do
     %Args{
       game: GameState.new(mode),
-      ui: UI,
-      in: fn -> TicTacToe.Io.get_position(device) end,
-      out: fn message -> TicTacToe.Io.output(device, message) end
+      display: DisplayState.new(TicTacToe.Io, UI, device)
     }
   end
 

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -4,20 +4,9 @@ defmodule TicTacToe.CLI do
 
   ./tic_tac_toe
   """
-  @player_cross "X"
-  @player_nought "O"
   @device :stdio
   def main(_) do
-    args = %Game{
-      board_manager: Board,
-      board: Board.new(),
-      ui: UI,
-      in: fn -> TicTacToe.Io.get_position(@device) end,
-      out: fn message -> TicTacToe.Io.output(@device, message) end,
-      players:
-        Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
-    }
-
+    args = Game.new(:human_vs_human, @device)
     TicTacToe.start(args)
   end
 end

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -4,13 +4,19 @@ defmodule TicTacToe.CLI do
 
   ./tic_tac_toe
   """
+  @player_cross "X"
+  @player_nought "O"
 
   def main(_) do
-    args = %{
-      board: Board,
+    args = %Game{
+      board_manager: Board,
+      board: Board.new(),
       ui: UI,
       io: TicTacToe.Io,
-      players: TicTacToe.Players.create(:human_vs_human)
+      device: :stdio,
+      out: nil,
+      players:
+        Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
     }
 
     TicTacToe.start(args)

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -6,15 +6,16 @@ defmodule TicTacToe.CLI do
   """
   @player_cross "X"
   @player_nought "O"
-
+  @device :stdio
   def main(_) do
     args = %Game{
       board_manager: Board,
       board: Board.new(),
       ui: UI,
       io: TicTacToe.Io,
-      device: :stdio,
-      out: nil,
+      device: @device,
+      in: fn -> TicTacToe.Io.get_position(@device) end,
+      out: fn message -> TicTacToe.Io.output(@device, message) end,
       players:
         Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
     }

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -12,8 +12,6 @@ defmodule TicTacToe.CLI do
       board_manager: Board,
       board: Board.new(),
       ui: UI,
-      io: TicTacToe.Io,
-      device: @device,
       in: fn -> TicTacToe.Io.get_position(@device) end,
       out: fn message -> TicTacToe.Io.output(@device, message) end,
       players:

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -6,7 +6,7 @@ defmodule TicTacToe.CLI do
   """
   @device :stdio
   def main(_) do
-    args = Game.new(:human_vs_human, @device)
+    args = Args.new(:human_vs_human, @device)
     TicTacToe.start(args)
   end
 end

--- a/lib/display_state.ex
+++ b/lib/display_state.ex
@@ -1,0 +1,12 @@
+defmodule DisplayState do
+  defstruct [:io, :device, :ui, :in, :out]
+
+  def new(io, ui, device) do
+    %DisplayState{
+      ui: ui,
+      in: fn -> io.get_position(device) end,
+      out: fn message -> io.output(device, message) end
+    }
+  end
+end
+

--- a/lib/game.ex
+++ b/lib/game.ex
@@ -1,4 +1,4 @@
 defmodule Game do
-  @enforce_keys [:board, :board_manager, :ui, :io, :players]
-  defstruct [:board_manager, :board, :ui, :io, :players]
+  @enforce_keys [:board, :board_manager, :ui, :io, :out, :device, :players]
+  defstruct [:board_manager, :board, :ui, :io, :out, :device, :players]
 end

--- a/lib/game.ex
+++ b/lib/game.ex
@@ -1,4 +1,4 @@
 defmodule Game do
-  @enforce_keys [:board, :board_manager, :ui, :io, :out, :device, :players]
-  defstruct [:board_manager, :board, :ui, :io, :in, :out, :device, :players]
+  @enforce_keys [:board, :board_manager, :ui, :out, :in, :players]
+  defstruct [:board_manager, :board, :ui, :in, :out, :players]
 end

--- a/lib/game.ex
+++ b/lib/game.ex
@@ -1,4 +1,17 @@
 defmodule Game do
   @enforce_keys [:board, :board_manager, :ui, :out, :in, :players]
   defstruct [:board_manager, :board, :ui, :in, :out, :players]
+  @player_cross "X"
+  @player_nought "O"
+
+  def new(mode, device \\ :stdio) do
+    %Game{
+      board_manager: Board,
+      board: Board.new(),
+      ui: UI,
+      in: fn -> TicTacToe.Io.get_position(device) end,
+      out: fn message -> TicTacToe.Io.output(device, message) end,
+      players: Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(mode))
+    }
+  end
 end

--- a/lib/game.ex
+++ b/lib/game.ex
@@ -1,0 +1,4 @@
+defmodule Game do
+  @enforce_keys [:board, :board_manager, :ui, :io, :players]
+  defstruct [:board_manager, :board, :ui, :io, :players]
+end

--- a/lib/game.ex
+++ b/lib/game.ex
@@ -1,4 +1,4 @@
 defmodule Game do
   @enforce_keys [:board, :board_manager, :ui, :io, :out, :device, :players]
-  defstruct [:board_manager, :board, :ui, :io, :out, :device, :players]
+  defstruct [:board_manager, :board, :ui, :io, :in, :out, :device, :players]
 end

--- a/lib/game_state.ex
+++ b/lib/game_state.ex
@@ -1,0 +1,24 @@
+defmodule GameState do
+  @player_cross "X"
+  @player_nought "O"
+  defstruct [:board, :players]
+
+  alias TicTacToe.Players
+
+  def new(player_mode, opts) do
+    %GameState{
+      board: Board.new(),
+      players:
+        Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(player_mode, opts))
+    }
+  end
+
+  def update_board(game, new_board) do
+    %GameState{game | board: new_board}
+  end
+
+  def update_players(game) do
+    %GameState{game | players: Players.next_turn(game.players)}
+  end
+end
+

--- a/lib/minimax.ex
+++ b/lib/minimax.ex
@@ -5,10 +5,10 @@ defmodule Minimax do
 
   defstruct [:board, :status, :players]
 
-  def new(board, maximising_player_mark, minimising_player_mark) do
+  def new(args, maximising_player_mark, minimising_player_mark) do
     %Minimax{
-      board: board,
-      status: Board.status(board),
+      board: args.board,
+      status: Board.status(args.board),
       players: %{
         maximising_player: maximising_player_mark,
         minimising_player: minimising_player_mark

--- a/lib/minimax.ex
+++ b/lib/minimax.ex
@@ -5,9 +5,9 @@ defmodule Minimax do
 
   defstruct [:board, :players]
 
-  def new(%GameState{} = game, maximising_player_mark, minimising_player_mark) do
+  def new(board, maximising_player_mark, minimising_player_mark) do
     %Minimax{
-      board: game.board,
+      board: board,
       players: %{
         maximising_player: maximising_player_mark,
         minimising_player: minimising_player_mark

--- a/lib/minimax.ex
+++ b/lib/minimax.ex
@@ -5,7 +5,7 @@ defmodule Minimax do
 
   defstruct [:board, :status, :players]
 
-  def new(%Args{game: game}, maximising_player_mark, minimising_player_mark) do
+  def new(%GameState{} = game, maximising_player_mark, minimising_player_mark) do
     %Minimax{
       board: game.board,
       status: Board.status(game.board),

--- a/lib/minimax.ex
+++ b/lib/minimax.ex
@@ -3,12 +3,11 @@ defmodule Minimax do
   @losing_score -10
   @draw_score 0
 
-  defstruct [:board, :status, :players]
+  defstruct [:board, :players]
 
   def new(%GameState{} = game, maximising_player_mark, minimising_player_mark) do
     %Minimax{
       board: game.board,
-      status: Board.status(game.board),
       players: %{
         maximising_player: maximising_player_mark,
         minimising_player: minimising_player_mark
@@ -17,7 +16,7 @@ defmodule Minimax do
   end
 
   def best_position(args) do
-    case args.status do
+    case Board.status(args.board) do
       :active -> minimax(args, :active, :maximising_player).position
       _ -> :error
     end
@@ -61,13 +60,11 @@ defmodule Minimax do
   defp mark(%{players: %{maximising_player: mark}}, :minimising_player), do: mark
 
   defp update_move(args, position, next_player),
-    do: args |> update_board(position, next_player) |> update_status()
+    do: args |> update_board(position, next_player)
 
   defp update_board(args, position, next_player),
     do: %{args | board: Board.update(args.board, position, mark(args, next_player))}
 
-  defp update_status(args), do: %{args | status: Board.status(args.board)}
-
   defp score_position(args, position, next_player),
-    do: %{position: position, score: minimax(args, args.status, next_player).score}
+    do: %{position: position, score: minimax(args, Board.status(args.board), next_player).score}
 end

--- a/lib/minimax.ex
+++ b/lib/minimax.ex
@@ -5,10 +5,10 @@ defmodule Minimax do
 
   defstruct [:board, :status, :players]
 
-  def new(args, maximising_player_mark, minimising_player_mark) do
+  def new(%Args{game: game}, maximising_player_mark, minimising_player_mark) do
     %Minimax{
-      board: args.board,
-      status: Board.status(args.board),
+      board: game.board,
+      status: Board.status(game.board),
       players: %{
         maximising_player: maximising_player_mark,
         minimising_player: minimising_player_mark

--- a/lib/player.ex
+++ b/lib/player.ex
@@ -1,0 +1,3 @@
+defprotocol TicTacToe.Player do
+  def choose_move(player, board)
+end

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -1,28 +1,28 @@
 defmodule PlayerHuman do
   @first_square 0
   @last_square 8
-  def move(board, message, args, io \\ :stdio) do
-    args.io.output(io, message)
+  def move(args, message \\ "") do
+    args.out.(message)
 
-    args.io.get_position(io)
-    |> valid_move?(board, args)
+    args.io.get_position(args.device)
+    |> valid_move?(args)
     |> case do
       {:ok, position} -> position
-      {:error, message} -> move(board, args.ui.message(message), args)
+      {:error, message} -> move(args, message)
     end
   end
 
-  def valid_move?(position, _board, _args) when not is_integer(position) do
+  def valid_move?(position, _args) when not is_integer(position) do
     {:error, :nan}
   end
 
-  def valid_move?(position, _board, _args)
+  def valid_move?(position, _args)
       when position < @first_square or position > @last_square do
     {:error, :out_of_bounds}
   end
 
-  def valid_move?(position, board, args) do
-    if args.board.available?(board, position) do
+  def valid_move?(position, args) do
+    if args.board_manager.available?(args.board, position) do
       {:ok, position}
     else
       {:error, :occupied}

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -31,12 +31,12 @@ defimpl Player, for: PlayerHuman do
     |> PlayerHuman.valid_move?(board)
     |> case do
       {:ok, position} -> position
-      {:error, message} -> error(display, message) |> choose_move(board)
+      {:error, message} -> error(player, message) |> choose_move(board)
     end
   end
 
-  defp error(%DisplayState{out: out, ui: ui} = display, message) do
-    out.(ui.message(message))
-    display
+  defp error(%PlayerHuman{display: display} = player, message) do
+    display.out.(display.ui.message(message))
+    player
   end
 end

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -1,14 +1,14 @@
 defmodule PlayerHuman do
   @first_square 0
   @last_square 8
-  def move(args, message \\ "") do
-    args.out.(message)
+  def move(%DisplayState{} = display, board, message \\ "") do
+    display.out.(message)
 
-    args.in.()
-    |> valid_move?(args.game.board)
+    display.in.()
+    |> valid_move?(board)
     |> case do
       {:ok, position} -> position
-      {:error, message} -> move(args, message)
+      {:error, message} -> move(display, message)
     end
   end
 

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -22,7 +22,7 @@ defmodule PlayerHuman do
   end
 
   def valid_move?(position, args) do
-    if args.board_manager.available?(args.board, position) do
+    if Board.available?(args.board, position) do
       {:ok, position}
     else
       {:error, :occupied}

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -1,24 +1,10 @@
 defmodule PlayerHuman do
-  defstruct [:display, :message]
   @first_square 0
   @last_square 8
+  defstruct [:display, :message]
 
   def new(%DisplayState{} = display) do
     %PlayerHuman{display: display}
-  end
-
-  def move(%DisplayState{} = display, board) do
-    display.in.()
-    |> valid_move?(board)
-    |> case do
-      {:ok, position} -> position
-      {:error, message} -> error(display, message) |> move(board)
-    end
-  end
-
-  def error(%DisplayState{ui: ui} = display, message) do
-    display.out.(ui.message(message))
-    display
   end
 
   def valid_move?(position, _) when not is_integer(position) do
@@ -36,5 +22,21 @@ defmodule PlayerHuman do
     else
       {:error, :occupied}
     end
+  end
+end
+
+defimpl Player, for: PlayerHuman do
+  def choose_move(%PlayerHuman{display: display} = player, board) do
+    display.in.()
+    |> PlayerHuman.valid_move?(board)
+    |> case do
+      {:ok, position} -> position
+      {:error, message} -> error(display, message) |> choose_move(board)
+    end
+  end
+
+  defp error(%DisplayState{out: out, ui: ui} = display, message) do
+    out.(ui.message(message))
+    display
   end
 end

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -1,10 +1,10 @@
 defmodule PlayerHuman do
   @first_square 0
   @last_square 8
-  defstruct [:display, :message]
+  defstruct [:in, :out, :ui]
 
-  def new(%DisplayState{} = display) do
-    %PlayerHuman{display: display}
+  def new(%DisplayState{in: input, out: output, ui: ui}) do
+    %PlayerHuman{in: input, out: output, ui: ui}
   end
 
   def valid_move?(position, _) when not is_integer(position) do
@@ -26,8 +26,8 @@ defmodule PlayerHuman do
 end
 
 defimpl TicTacToe.Player, for: PlayerHuman do
-  def choose_move(%PlayerHuman{display: display} = player, board) do
-    display.in.()
+  def choose_move(%PlayerHuman{in: input} = player, board) do
+    input.()
     |> PlayerHuman.valid_move?(board)
     |> case do
       {:ok, position} -> position
@@ -35,8 +35,10 @@ defimpl TicTacToe.Player, for: PlayerHuman do
     end
   end
 
-  defp error(%PlayerHuman{display: display} = player, message) do
-    display.out.(display.ui.message(message))
+  defp error(%PlayerHuman{ui: ui, out: out} = player, message) do
+    ui.message(message)
+    |> out.()
+
     player
   end
 end

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -25,7 +25,7 @@ defmodule PlayerHuman do
   end
 end
 
-defimpl Player, for: PlayerHuman do
+defimpl TicTacToe.Player, for: PlayerHuman do
   def choose_move(%PlayerHuman{display: display} = player, board) do
     display.in.()
     |> PlayerHuman.valid_move?(board)

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -12,12 +12,12 @@ defmodule PlayerHuman do
     |> valid_move?(board)
     |> case do
       {:ok, position} -> position
-      {:error, message} -> error(display, message) |> move(display)
+      {:error, message} -> error(display, message) |> move(board)
     end
   end
 
-  def error(display, message) do
-    display.out.(message)
+  def error(%DisplayState{ui: ui} = display, message) do
+    display.out.(ui.message(message))
     display
   end
 

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -4,7 +4,7 @@ defmodule PlayerHuman do
   def move(args, message \\ "") do
     args.out.(message)
 
-    args.io.get_position(args.device)
+    args.in.()
     |> valid_move?(args)
     |> case do
       {:ok, position} -> position

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -3,19 +3,22 @@ defmodule PlayerHuman do
   @first_square 0
   @last_square 8
 
-  def new(%DisplayState{} = display, message \\ "") do
-    %PlayerHuman{display: display, message: message}
+  def new(%DisplayState{} = display) do
+    %PlayerHuman{display: display}
   end
 
-  def move(%DisplayState{} = display, board, message \\ "") do
-    display.out.(message)
-
+  def move(%DisplayState{} = display, board) do
     display.in.()
     |> valid_move?(board)
     |> case do
       {:ok, position} -> position
-      {:error, message} -> move(display, message)
+      {:error, message} -> error(display, message) |> move(display)
     end
+  end
+
+  def error(display, message) do
+    display.out.(message)
+    display
   end
 
   def valid_move?(position, _) when not is_integer(position) do

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -1,6 +1,12 @@
 defmodule PlayerHuman do
+  defstruct [:display, :message]
   @first_square 0
   @last_square 8
+
+  def new(%DisplayState{} = display, message \\ "") do
+    %PlayerHuman{display: display, message: message}
+  end
+
   def move(%DisplayState{} = display, board, message \\ "") do
     display.out.(message)
 

--- a/lib/player_human.ex
+++ b/lib/player_human.ex
@@ -5,24 +5,24 @@ defmodule PlayerHuman do
     args.out.(message)
 
     args.in.()
-    |> valid_move?(args)
+    |> valid_move?(args.game.board)
     |> case do
       {:ok, position} -> position
       {:error, message} -> move(args, message)
     end
   end
 
-  def valid_move?(position, _args) when not is_integer(position) do
+  def valid_move?(position, _) when not is_integer(position) do
     {:error, :nan}
   end
 
-  def valid_move?(position, _args)
+  def valid_move?(position, _)
       when position < @first_square or position > @last_square do
     {:error, :out_of_bounds}
   end
 
-  def valid_move?(position, args) do
-    if Board.available?(args.board, position) do
+  def valid_move?(position, board) do
+    if Board.available?(board, position) do
       {:ok, position}
     else
       {:error, :occupied}

--- a/lib/player_minimax.ex
+++ b/lib/player_minimax.ex
@@ -5,7 +5,7 @@ defmodule PlayerMinimax do
     do: %PlayerMinimax{player: player_mark, opponent: opponent_mark}
 end
 
-defimpl Player, for: PlayerMinimax do
+defimpl TicTacToe.Player, for: PlayerMinimax do
   def choose_move(%PlayerMinimax{player: player, opponent: opponent}, board) do
     Minimax.new(board, player, opponent)
     |> Minimax.best_position()

--- a/lib/player_minimax.ex
+++ b/lib/player_minimax.ex
@@ -1,6 +1,12 @@
 defmodule PlayerMinimax do
-  def move(board, _message, args, _io \\ :stdio) do
-    Minimax.new(board, args.player, args.opponent)
+  alias TicTacToe.Players, as: Players
+
+  def move(args, _message \\ "") do
+    Minimax.new(
+      args,
+      Players.current_mark(args.players),
+      Players.opponent_mark(args.players)
+    )
     |> Minimax.best_position()
   end
 end

--- a/lib/player_minimax.ex
+++ b/lib/player_minimax.ex
@@ -1,9 +1,9 @@
 defmodule PlayerMinimax do
   alias TicTacToe.Players, as: Players
 
-  def move(%Args{game: game} = args, _message \\ "") do
+  def move(%GameState{} = game, _message \\ "") do
     Minimax.new(
-      args,
+      game,
       Players.current_mark(game.players),
       Players.opponent_mark(game.players)
     )

--- a/lib/player_minimax.ex
+++ b/lib/player_minimax.ex
@@ -3,8 +3,10 @@ defmodule PlayerMinimax do
 
   def new(player_mark, opponent_mark),
     do: %PlayerMinimax{player: player_mark, opponent: opponent_mark}
+end
 
-  def move(%PlayerMinimax{player: player, opponent: opponent}, board) do
+defimpl Player, for: PlayerMinimax do
+  def choose_move(%PlayerMinimax{player: player, opponent: opponent}, board) do
     Minimax.new(board, player, opponent)
     |> Minimax.best_position()
   end

--- a/lib/player_minimax.ex
+++ b/lib/player_minimax.ex
@@ -1,11 +1,11 @@
 defmodule PlayerMinimax do
   alias TicTacToe.Players, as: Players
 
-  def move(args, _message \\ "") do
+  def move(%Args{game: game} = args, _message \\ "") do
     Minimax.new(
       args,
-      Players.current_mark(args.players),
-      Players.opponent_mark(args.players)
+      Players.current_mark(game.players),
+      Players.opponent_mark(game.players)
     )
     |> Minimax.best_position()
   end

--- a/lib/player_minimax.ex
+++ b/lib/player_minimax.ex
@@ -1,12 +1,6 @@
 defmodule PlayerMinimax do
-  alias TicTacToe.Players, as: Players
-
-  def move(%GameState{} = game, _message \\ "") do
-    Minimax.new(
-      game,
-      Players.current_mark(game.players),
-      Players.opponent_mark(game.players)
-    )
+  def move(board, player_mark, opponent_mark) do
+    Minimax.new(board, player_mark, opponent_mark)
     |> Minimax.best_position()
   end
 end

--- a/lib/player_minimax.ex
+++ b/lib/player_minimax.ex
@@ -1,6 +1,11 @@
 defmodule PlayerMinimax do
-  def move(board, player_mark, opponent_mark) do
-    Minimax.new(board, player_mark, opponent_mark)
+  defstruct [:player, :opponent]
+
+  def new(player_mark, opponent_mark),
+    do: %PlayerMinimax{player: player_mark, opponent: opponent_mark}
+
+  def move(%PlayerMinimax{player: player, opponent: opponent}, board) do
+    Minimax.new(board, player, opponent)
     |> Minimax.best_position()
   end
 end

--- a/lib/players.ex
+++ b/lib/players.ex
@@ -7,11 +7,11 @@ defmodule TicTacToe.Players do
     [PlayerHuman.new(display), PlayerHuman.new(display)]
   end
 
-  def create(:human_vs_minimax), do: [PlayerHuman, PlayerMinimax]
-
   def create(:minimax_vs_minimax, _) do
     [PlayerMinimax.new("X", "O"), PlayerMinimax.new("O", "X")]
   end
+
+  def create(:human_vs_minimax), do: [PlayerHuman, PlayerMinimax]
 
   def next_turn(players) do
     Enum.reverse(players)
@@ -31,8 +31,4 @@ defmodule TicTacToe.Players do
     {_, player} = List.first(players)
     player
   end
-end
-
-defprotocol Player do
-  def choose_move(player, board)
 end

--- a/lib/players.ex
+++ b/lib/players.ex
@@ -1,13 +1,12 @@
 defmodule TicTacToe.Players do
-  def create(:human, %DisplayState{} = display) do
-    PlayerHuman.new(display)
-  end
-
   def create(:minimax, player_mark, opponent_mark) do
     PlayerMinimax.new(player_mark, opponent_mark)
   end
 
-  def create(:human_vs_human), do: [PlayerHuman, PlayerHuman]
+  def create(:human_vs_human, %DisplayState{} = display) do
+    [PlayerHuman.new(display), PlayerHuman.new(display)]
+  end
+
   def create(:human_vs_minimax), do: [PlayerHuman, PlayerMinimax]
   def create(:minimax_vs_minimax), do: [PlayerMinimax, PlayerMinimax]
 

--- a/lib/players.ex
+++ b/lib/players.ex
@@ -1,4 +1,12 @@
 defmodule TicTacToe.Players do
+  def create(:human, %DisplayState{} = display) do
+    PlayerHuman.new(display)
+  end
+
+  def create(:minimax, player_mark, opponent_mark) do
+    PlayerMinimax.new(player_mark, opponent_mark)
+  end
+
   def create(:human_vs_human), do: [PlayerHuman, PlayerHuman]
   def create(:human_vs_minimax), do: [PlayerHuman, PlayerMinimax]
   def create(:minimax_vs_minimax), do: [PlayerMinimax, PlayerMinimax]

--- a/lib/players.ex
+++ b/lib/players.ex
@@ -24,5 +24,5 @@ defmodule TicTacToe.Players do
 end
 
 defprotocol Player do
-  def best_move(player, board)
+  def choose_move(player, board)
 end

--- a/lib/players.ex
+++ b/lib/players.ex
@@ -1,3 +1,22 @@
 defmodule TicTacToe.Players do
   def create(:human_vs_human), do: [PlayerHuman, PlayerHuman]
+
+  def next_turn(players) do
+    Enum.reverse(players)
+  end
+
+  def current_mark(players) do
+    {mark, _} = List.first(players)
+    mark
+  end
+
+  def opponent_mark(players) do
+    {mark, _} = List.last(players)
+    mark
+  end
+
+  def current_player(players) do
+    {_, player} = List.first(players)
+    player
+  end
 end

--- a/lib/players.ex
+++ b/lib/players.ex
@@ -1,5 +1,7 @@
 defmodule TicTacToe.Players do
   def create(:human_vs_human), do: [PlayerHuman, PlayerHuman]
+  def create(:human_vs_minimax), do: [PlayerHuman, PlayerMinimax]
+  def create(:minimax_vs_minimax), do: [PlayerMinimax, PlayerMinimax]
 
   def next_turn(players) do
     Enum.reverse(players)

--- a/lib/players.ex
+++ b/lib/players.ex
@@ -8,7 +8,10 @@ defmodule TicTacToe.Players do
   end
 
   def create(:human_vs_minimax), do: [PlayerHuman, PlayerMinimax]
-  def create(:minimax_vs_minimax), do: [PlayerMinimax, PlayerMinimax]
+
+  def create(:minimax_vs_minimax, _) do
+    [PlayerMinimax.new("X", "O"), PlayerMinimax.new("O", "X")]
+  end
 
   def next_turn(players) do
     Enum.reverse(players)

--- a/lib/players.ex
+++ b/lib/players.ex
@@ -22,3 +22,7 @@ defmodule TicTacToe.Players do
     player
   end
 end
+
+defprotocol Player do
+  def best_move(player, board)
+end

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -18,9 +18,9 @@ defmodule TicTacToe do
 
     pos = Players.current_player(args.players).move(args)
 
-    updated_board = args.board_manager.update(args.board, pos, Players.current_mark(args.players))
+    updated_board = Board.update(args.board, pos, Players.current_mark(args.players))
 
-    args.board_manager.status(updated_board)
+    Board.status(updated_board)
     |> case do
       :won ->
         next(:won, Args.update_board(args, updated_board))

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -23,17 +23,13 @@ defmodule TicTacToe do
     args.board_manager.status(updated_board)
     |> case do
       :won ->
-        next(:won, %{args | board: updated_board})
+        next(:won, Args.update_board(args, updated_board))
 
       :drawn ->
-        next(:drawn, %{args | board: updated_board})
+        next(:drawn, Args.update_board(args, updated_board))
 
       :active ->
-        next(:active, %{
-          args
-          | board: updated_board,
-            players: Players.next_turn(args.players)
-        })
+        next(:active, Args.update_board(args, updated_board) |> Args.update_players())
     end
   end
 

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -6,12 +6,10 @@ defmodule TicTacToe do
   """
 
   def start(args) do
-    out = fn message -> args.io.output(args.device, message) end
-
     [args.ui.message(:title), args.ui.message(:intro)]
-    |> out.()
+    |> args.out.()
 
-    next(:active, %{args | out: out})
+    next(:active, args)
   end
 
   defp next(:active, args) do

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -1,5 +1,5 @@
 defmodule TicTacToe do
-  alias TicTacToe.Players, as: Players
+  alias TicTacToe.{Players, Player}
 
   @moduledoc """
   Documentation for TicTacToe.

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -5,18 +5,21 @@ defmodule TicTacToe do
   Documentation for TicTacToe.
   """
 
-  def start(args) do
-    [args.ui.message(:title), args.ui.message(:intro)]
-    |> args.out.()
+  def start(%Args{display: display} = args) do
+    [display.ui.message(:title), display.ui.message(:intro)]
+    |> display.out.()
 
     next(:active, args)
   end
 
-  defp next(:active, %Args{game: game} = args) do
-    [args.ui.draw_board(game.board), args.ui.player_turn(Players.current_mark(game.players))]
-    |> args.out.()
+  defp next(:active, %Args{game: game, display: display} = args) do
+    [
+      display.ui.draw_board(game.board),
+      display.ui.player_turn(Players.current_mark(game.players))
+    ]
+    |> display.out.()
 
-    pos = Players.current_player(game.players).move(args)
+    pos = Players.current_player(game.players).move(display, game.board)
 
     updated_board = Board.update(game.board, pos, Players.current_mark(game.players))
 
@@ -33,18 +36,18 @@ defmodule TicTacToe do
     end
   end
 
-  defp next(:drawn, %Args{game: game} = args) do
-    [args.ui.draw_board(game.board), args.ui.draw()]
-    |> args.out.()
+  defp next(:drawn, %Args{game: game, display: display}) do
+    [display.ui.draw_board(game.board), display.ui.draw()]
+    |> display.out.()
 
     :drawn
   end
 
-  defp next(:won, %Args{game: game} = args) do
+  defp next(:won, %Args{game: game, display: display}) do
     mark = Players.current_mark(game.players)
 
-    [args.ui.draw_board(game.board), args.ui.winner(mark)]
-    |> args.out.()
+    [display.ui.draw_board(game.board), display.ui.winner(mark)]
+    |> display.out.()
 
     :won
   end

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -19,7 +19,9 @@ defmodule TicTacToe do
     ]
     |> display.out.()
 
-    pos = Players.current_player(game.players).move(display, game.board)
+    pos =
+      Players.current_player(game.players)
+      |> Player.choose_move(game.board)
 
     updated_board = Board.update(game.board, pos, Players.current_mark(game.players))
 

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -45,7 +45,7 @@ defmodule TicTacToe do
   end
 
   defp next(:won, args) do
-    {_, mark} = List.first(args.players)
+    mark = Players.current_mark(args.players)
 
     [args.ui.draw_board(args.board), args.ui.winner(mark)]
     |> args.out.()

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -19,19 +19,7 @@ defmodule TicTacToe do
     [args.ui.draw_board(args.board), args.ui.player_turn(current_mark)]
     |> args.out.()
 
-    pos =
-      current_player.move(
-        args.board,
-        "",
-        %{
-          board: args.board_manager,
-          player: current_mark,
-          opponent: opponent_mark,
-          ui: args.ui,
-          io: args.io
-        },
-        args.device
-      )
+    pos = current_player.move(args)
 
     updated_board = args.board_manager.update(args.board, pos, current_mark)
 

--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -12,13 +12,13 @@ defmodule TicTacToe do
     next(:active, args)
   end
 
-  defp next(:active, args) do
-    [args.ui.draw_board(args.board), args.ui.player_turn(Players.current_mark(args.players))]
+  defp next(:active, %Args{game: game} = args) do
+    [args.ui.draw_board(game.board), args.ui.player_turn(Players.current_mark(game.players))]
     |> args.out.()
 
-    pos = Players.current_player(args.players).move(args)
+    pos = Players.current_player(game.players).move(args)
 
-    updated_board = Board.update(args.board, pos, Players.current_mark(args.players))
+    updated_board = Board.update(game.board, pos, Players.current_mark(game.players))
 
     Board.status(updated_board)
     |> case do
@@ -33,17 +33,17 @@ defmodule TicTacToe do
     end
   end
 
-  defp next(:drawn, args) do
-    [args.ui.draw_board(args.board), args.ui.draw()]
+  defp next(:drawn, %Args{game: game} = args) do
+    [args.ui.draw_board(game.board), args.ui.draw()]
     |> args.out.()
 
     :drawn
   end
 
-  defp next(:won, args) do
-    mark = Players.current_mark(args.players)
+  defp next(:won, %Args{game: game} = args) do
+    mark = Players.current_mark(game.players)
 
-    [args.ui.draw_board(args.board), args.ui.winner(mark)]
+    [args.ui.draw_board(game.board), args.ui.winner(mark)]
     |> args.out.()
 
     :won

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -3,15 +3,17 @@ defmodule PlayerHumanTest do
 
   test "move/4 can get a valid move from the user and return the zero-indexed integer" do
     {:ok, io} = StringIO.open("1")
-    args = Args.new(:human_vs_human, io)
-    assert PlayerHuman.move(args) == 0
+    display = DisplayState.new(TicTacToe.Io, UI, io)
+    board = Board.new()
+    assert PlayerHuman.move(display, board) == 0
   end
 
   test "move/4 will prompt again if user does not submit valid move" do
     {:ok, io} = StringIO.open("cat\n1")
-    args = Args.new(:human_vs_human, io)
+    display = DisplayState.new(TicTacToe.Io, UI, io)
+    board = Board.new()
 
-    assert PlayerHuman.move(args) == 0
+    assert PlayerHuman.move(display, board) == 0
   end
 
   test "valid_move?/3 returns :ok when placing valid move on an empty board" do

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -3,39 +3,39 @@ defmodule PlayerHumanTest do
 
   test "move/4 can get a valid move from the user and return the zero-indexed integer" do
     {:ok, io} = StringIO.open("1")
-    args = Game.new(:human_vs_human, io)
+    args = Args.new(:human_vs_human, io)
     assert PlayerHuman.move(args) == 0
   end
 
   test "move/4 will prompt again if user does not submit valid move" do
     {:ok, io} = StringIO.open("cat\n1")
-    args = Game.new(:human_vs_human, io)
+    args = Args.new(:human_vs_human, io)
 
     assert PlayerHuman.move(args) == 0
   end
 
   test "valid_move?/3 returns :ok when placing valid move on an empty board" do
     position = 1
-    args = Game.new(:human_vs_human)
+    args = Args.new(:human_vs_human)
     assert PlayerHuman.valid_move?(position, args) == {:ok, 1}
   end
 
   test "valid_move?/3 returns {:error, :occupied} if move is already taken" do
-    args = Game.new(:human_vs_human)
+    args = Args.new(:human_vs_human)
     position = 2
     {mark, _} = List.first(args.players)
-    updated_args = %Game{args | board: args.board_manager.update(args.board, position, mark)}
+    updated_args = %Args{args | board: args.board_manager.update(args.board, position, mark)}
     assert PlayerHuman.valid_move?(position, updated_args) == {:error, :occupied}
   end
 
   test "valid_move?/3 returns {:error, :out_of_bounds} if number too big/small" do
-    args = Game.new(:human_vs_human)
+    args = Args.new(:human_vs_human)
     position = 25
     assert PlayerHuman.valid_move?(position, args) == {:error, :out_of_bounds}
   end
 
   test "valid_move?/3 returns {:error, :nan} if position is not an integer" do
-    args = Game.new(:human_vs_human)
+    args = Args.new(:human_vs_human)
     position = "cat"
     assert PlayerHuman.valid_move?(position, args) == {:error, :nan}
   end

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -21,22 +21,24 @@ defmodule PlayerHumanTest do
   end
 
   test "valid_move?/3 returns {:error, :occupied} if move is already taken" do
-    args = Args.new(:human_vs_human)
-    position = 2
-    {mark, _} = List.first(args.players)
-    updated_args = %Args{args | board: Board.update(args.board, position, mark)}
-    assert PlayerHuman.valid_move?(position, updated_args) == {:error, :occupied}
+    position = 1
+
+    board =
+      Board.new()
+      |> Board.update(position, "x")
+
+    assert PlayerHuman.valid_move?(position, board) == {:error, :occupied}
   end
 
   test "valid_move?/3 returns {:error, :out_of_bounds} if number too big/small" do
-    args = Args.new(:human_vs_human)
     position = 25
-    assert PlayerHuman.valid_move?(position, args) == {:error, :out_of_bounds}
+    board = Board.new()
+    assert PlayerHuman.valid_move?(position, board) == {:error, :out_of_bounds}
   end
 
   test "valid_move?/3 returns {:error, :nan} if position is not an integer" do
-    args = Args.new(:human_vs_human)
+    board = Board.new()
     position = "cat"
-    assert PlayerHuman.valid_move?(position, args) == {:error, :nan}
+    assert PlayerHuman.valid_move?(position, board) == {:error, :nan}
   end
 end

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -9,21 +9,24 @@ defmodule PlayerHumanTest do
     io: TicTacToe.Io,
     device: :stdio,
     out: nil,
+    in: nil,
     players: Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
   }
 
   test "move/4 can get a valid move from the user and return the zero-indexed integer" do
     {:ok, io} = StringIO.open("1")
+    input = fn -> TicTacToe.Io.get_position(io) end
     out = fn message -> @args.io.output(io, message) end
 
-    assert PlayerHuman.move(%Game{@args | out: out, device: io}) == 0
+    assert PlayerHuman.move(%Game{@args | in: input, out: out, device: io}) == 0
   end
 
   test "move/4 will prompt again if user does not submit valid move" do
     {:ok, io} = StringIO.open("cat\n1")
+    input = fn -> TicTacToe.Io.get_position(io) end
     out = fn message -> @args.io.output(io, message) end
 
-    assert PlayerHuman.move(%Game{@args | out: out, device: io}) == 0
+    assert PlayerHuman.move(%Game{@args | in: input, out: out, device: io}) == 0
   end
 
   test "valid_move?/3 returns :ok when placing valid move on an empty board" do

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -6,8 +6,6 @@ defmodule PlayerHumanTest do
     board_manager: Board,
     board: Board.new(),
     ui: UI,
-    io: TicTacToe.Io,
-    device: :stdio,
     out: nil,
     in: nil,
     players: Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
@@ -16,17 +14,17 @@ defmodule PlayerHumanTest do
   test "move/4 can get a valid move from the user and return the zero-indexed integer" do
     {:ok, io} = StringIO.open("1")
     input = fn -> TicTacToe.Io.get_position(io) end
-    out = fn message -> @args.io.output(io, message) end
+    out = fn message -> TicTacToe.Io.output(io, message) end
 
-    assert PlayerHuman.move(%Game{@args | in: input, out: out, device: io}) == 0
+    assert PlayerHuman.move(%Game{@args | in: input, out: out}) == 0
   end
 
   test "move/4 will prompt again if user does not submit valid move" do
     {:ok, io} = StringIO.open("cat\n1")
     input = fn -> TicTacToe.Io.get_position(io) end
-    out = fn message -> @args.io.output(io, message) end
+    out = fn message -> TicTacToe.Io.output(io, message) end
 
-    assert PlayerHuman.move(%Game{@args | in: input, out: out, device: io}) == 0
+    assert PlayerHuman.move(%Game{@args | in: input, out: out}) == 0
   end
 
   test "valid_move?/3 returns :ok when placing valid move on an empty board" do

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -1,6 +1,6 @@
 defmodule PlayerHumanTest do
   use ExUnit.Case
-
+alias TicTacToe.Player
   test "move/4 can get a valid move from the user and return the zero-indexed integer" do
     {:ok, io} = StringIO.open("1")
 

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -1,51 +1,42 @@
 defmodule PlayerHumanTest do
   use ExUnit.Case
-  @player_cross "X"
-  @player_nought "O"
-  @args %Game{
-    board_manager: Board,
-    board: Board.new(),
-    ui: UI,
-    out: nil,
-    in: nil,
-    players: Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
-  }
 
   test "move/4 can get a valid move from the user and return the zero-indexed integer" do
     {:ok, io} = StringIO.open("1")
-    input = fn -> TicTacToe.Io.get_position(io) end
-    out = fn message -> TicTacToe.Io.output(io, message) end
-
-    assert PlayerHuman.move(%Game{@args | in: input, out: out}) == 0
+    args = Game.new(:human_vs_human, io)
+    assert PlayerHuman.move(args) == 0
   end
 
   test "move/4 will prompt again if user does not submit valid move" do
     {:ok, io} = StringIO.open("cat\n1")
-    input = fn -> TicTacToe.Io.get_position(io) end
-    out = fn message -> TicTacToe.Io.output(io, message) end
+    args = Game.new(:human_vs_human, io)
 
-    assert PlayerHuman.move(%Game{@args | in: input, out: out}) == 0
+    assert PlayerHuman.move(args) == 0
   end
 
   test "valid_move?/3 returns :ok when placing valid move on an empty board" do
     position = 1
-    assert PlayerHuman.valid_move?(position, @args) == {:ok, 1}
+    args = Game.new(:human_vs_human)
+    assert PlayerHuman.valid_move?(position, args) == {:ok, 1}
   end
 
   test "valid_move?/3 returns {:error, :occupied} if move is already taken" do
+    args = Game.new(:human_vs_human)
     position = 2
-    {mark, _} = List.first(@args.players)
-    updated_args = %Game{@args | board: Board.update(@args.board, position, mark)}
+    {mark, _} = List.first(args.players)
+    updated_args = %Game{args | board: args.board_manager.update(args.board, position, mark)}
     assert PlayerHuman.valid_move?(position, updated_args) == {:error, :occupied}
   end
 
   test "valid_move?/3 returns {:error, :out_of_bounds} if number too big/small" do
+    args = Game.new(:human_vs_human)
     position = 25
-    assert PlayerHuman.valid_move?(position, @args) == {:error, :out_of_bounds}
+    assert PlayerHuman.valid_move?(position, args) == {:error, :out_of_bounds}
   end
 
   test "valid_move?/3 returns {:error, :nan} if position is not an integer" do
+    args = Game.new(:human_vs_human)
     position = "cat"
-    assert PlayerHuman.valid_move?(position, @args) == {:error, :nan}
+    assert PlayerHuman.valid_move?(position, args) == {:error, :nan}
   end
 end

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -24,7 +24,7 @@ defmodule PlayerHumanTest do
     args = Args.new(:human_vs_human)
     position = 2
     {mark, _} = List.first(args.players)
-    updated_args = %Args{args | board: args.board_manager.update(args.board, position, mark)}
+    updated_args = %Args{args | board: Board.update(args.board, position, mark)}
     assert PlayerHuman.valid_move?(position, updated_args) == {:error, :occupied}
   end
 

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -3,17 +3,22 @@ defmodule PlayerHumanTest do
 
   test "move/4 can get a valid move from the user and return the zero-indexed integer" do
     {:ok, io} = StringIO.open("1")
-    display = DisplayState.new(TicTacToe.Io, UI, io)
-    board = Board.new()
-    assert PlayerHuman.move(display, board) == 0
+
+    player =
+      DisplayState.new(TicTacToe.Io, UI, io)
+      |> PlayerHuman.new()
+
+    assert Player.choose_move(player, Board.new()) == 0
   end
 
   test "move/4 will prompt again if user does not submit valid move" do
     {:ok, io} = StringIO.open("cat\n1")
-    display = DisplayState.new(TicTacToe.Io, UI, io)
-    board = Board.new()
 
-    assert PlayerHuman.move(display, board) == 0
+    player =
+      DisplayState.new(TicTacToe.Io, UI, io)
+      |> PlayerHuman.new()
+
+    assert Player.choose_move(player, Board.new()) == 0
   end
 
   test "valid_move?/3 returns :ok when placing valid move on an empty board" do

--- a/test/player_minimax_test.exs
+++ b/test/player_minimax_test.exs
@@ -1,5 +1,6 @@
 defmodule PlayerMinimaxTest do
   use ExUnit.Case
+  alias TicTacToe.Player
   @minimax PlayerMinimax.new("X", "O")
 
   test "returns :error if game is over" do

--- a/test/player_minimax_test.exs
+++ b/test/player_minimax_test.exs
@@ -2,104 +2,66 @@ defmodule PlayerMinimaxTest do
   use ExUnit.Case
 
   test "returns :error if game is over" do
-    state =
+    updated_board =
       Board.new()
       |> Board.update(0, "X")
       |> Board.update(1, "X")
       |> Board.update(2, "X")
 
-    args = %{
-      board: state,
-      player: "X",
-      opponent: "O"
-    }
+    args = Args.new(:human_vs_minimax) |> Args.update_board(updated_board)
 
-    assert PlayerMinimax.move(state, "", args) == :error
+    assert PlayerMinimax.move(args) == :error
   end
 
   test "move plays for a horizontal win" do
-    board = Board.new()
-
-    args = %{
-      board: board,
-      player: "X",
-      opponent: "O"
-    }
-
-    state =
-      board
+    updated_board =
+      Board.new()
       |> Board.update(0, "X")
       |> Board.update(1, "X")
 
-    assert PlayerMinimax.move(state, "", args) == 2
+    args = Args.new(:human_vs_minimax) |> Args.update_board(updated_board)
+
+    assert PlayerMinimax.move(args) == 2
   end
 
   test "move plays for a vertical win" do
-    board = Board.new()
-
-    args = %{
-      board: board,
-      player: "X",
-      opponent: "O"
-    }
-
-    state =
-      board
+    updated_board =
+      Board.new()
       |> Board.update(0, "X")
       |> Board.update(3, "X")
 
-    assert PlayerMinimax.move(state, "", args) == 6
+    args = Args.new(:human_vs_minimax) |> Args.update_board(updated_board)
+    assert PlayerMinimax.move(args) == 6
   end
 
   test "move plays for a diagonal win" do
-    board = Board.new()
-
-    args = %{
-      board: board,
-      player: "X",
-      opponent: "O"
-    }
-
-    state =
-      board
+    updated_board =
+      Board.new()
       |> Board.update(0, "X")
       |> Board.update(4, "X")
 
-    assert PlayerMinimax.move(state, "", args) == 8
+    args = Args.new(:human_vs_minimax) |> Args.update_board(updated_board)
+    assert PlayerMinimax.move(args) == 8
   end
 
   test "move blocks opponent from a win" do
-    board = Board.new()
+    updated_board =
+      Board.new()
+      |> Board.update(6, "X")
+      |> Board.update(8, "X")
 
-    args = %{
-      board: board,
-      player: "X",
-      opponent: "O"
-    }
-
-    state =
-      board
-      |> Board.update(6, "O")
-      |> Board.update(8, "O")
-
-    assert PlayerMinimax.move(state, "", args) == 7
+    args = Args.new(:human_vs_minimax) |> Args.update_board(updated_board)
+    assert PlayerMinimax.move(args) == 7
   end
 
   test "move plays for closest win" do
-    board = Board.new()
-
-    args = %{
-      board: board,
-      player: "X",
-      opponent: "O"
-    }
-
-    state =
-      board
+    updated_board =
+      Board.new()
       |> Board.update(0, "X")
       |> Board.update(1, "X")
       |> Board.update(8, "X")
 
-    assert PlayerMinimax.move(state, "", args) == 2
+    args = Args.new(:human_vs_minimax) |> Args.update_board(updated_board)
+    assert PlayerMinimax.move(args) == 2
   end
 end

--- a/test/player_minimax_test.exs
+++ b/test/player_minimax_test.exs
@@ -2,66 +2,64 @@ defmodule PlayerMinimaxTest do
   use ExUnit.Case
 
   test "returns :error if game is over" do
-    updated_board =
+    game_state =
       Board.new()
       |> Board.update(0, "X")
       |> Board.update(1, "X")
       |> Board.update(2, "X")
+      |> GameState.new(:human_vs_minimax)
 
-    args = Args.new(:human_vs_minimax) |> Args.update_board(updated_board)
-
-    assert PlayerMinimax.move(args) == :error
+    assert PlayerMinimax.move(game_state) == :error
   end
 
   test "move plays for a horizontal win" do
-    updated_board =
+    game_state =
       Board.new()
       |> Board.update(0, "X")
       |> Board.update(1, "X")
+      |> GameState.new(:human_vs_minimax)
 
-    args = Args.new(:human_vs_minimax) |> Args.update_board(updated_board)
-
-    assert PlayerMinimax.move(args) == 2
+    assert PlayerMinimax.move(game_state) == 2
   end
 
   test "move plays for a vertical win" do
-    updated_board =
+    game_state =
       Board.new()
       |> Board.update(0, "X")
       |> Board.update(3, "X")
+      |> GameState.new(:human_vs_minimax)
 
-    args = Args.new(:human_vs_minimax) |> Args.update_board(updated_board)
-    assert PlayerMinimax.move(args) == 6
+    assert PlayerMinimax.move(game_state) == 6
   end
 
   test "move plays for a diagonal win" do
-    updated_board =
+    game_state =
       Board.new()
       |> Board.update(0, "X")
       |> Board.update(4, "X")
+      |> GameState.new(:human_vs_minimax)
 
-    args = Args.new(:human_vs_minimax) |> Args.update_board(updated_board)
-    assert PlayerMinimax.move(args) == 8
+    assert PlayerMinimax.move(game_state) == 8
   end
 
   test "move blocks opponent from a win" do
-    updated_board =
+    game_state =
       Board.new()
-      |> Board.update(6, "X")
-      |> Board.update(8, "X")
+      |> Board.update(6, "O")
+      |> Board.update(8, "O")
+      |> GameState.new(:human_vs_minimax)
 
-    args = Args.new(:human_vs_minimax) |> Args.update_board(updated_board)
-    assert PlayerMinimax.move(args) == 7
+    assert PlayerMinimax.move(game_state) == 7
   end
 
   test "move plays for closest win" do
-    updated_board =
+    game_state =
       Board.new()
       |> Board.update(0, "X")
       |> Board.update(1, "X")
       |> Board.update(8, "X")
+      |> GameState.new(:human_vs_minimax)
 
-    args = Args.new(:human_vs_minimax) |> Args.update_board(updated_board)
-    assert PlayerMinimax.move(args) == 2
+    assert PlayerMinimax.move(game_state) == 2
   end
 end

--- a/test/player_minimax_test.exs
+++ b/test/player_minimax_test.exs
@@ -9,7 +9,7 @@ defmodule PlayerMinimaxTest do
       |> Board.update(1, "X")
       |> Board.update(2, "X")
 
-    assert PlayerMinimax.move(@minimax, board) == :error
+    assert Player.choose_move(@minimax, board) == :error
   end
 
   test "move plays for a horizontal win" do
@@ -18,7 +18,7 @@ defmodule PlayerMinimaxTest do
       |> Board.update(0, "X")
       |> Board.update(1, "X")
 
-    assert PlayerMinimax.move(@minimax, board) == 2
+    assert Player.choose_move(@minimax, board) == 2
   end
 
   test "move plays for a vertical win" do
@@ -27,7 +27,7 @@ defmodule PlayerMinimaxTest do
       |> Board.update(0, "X")
       |> Board.update(3, "X")
 
-    assert PlayerMinimax.move(@minimax, board) == 6
+    assert Player.choose_move(@minimax, board) == 6
   end
 
   test "move plays for a diagonal win" do
@@ -36,7 +36,7 @@ defmodule PlayerMinimaxTest do
       |> Board.update(0, "X")
       |> Board.update(4, "X")
 
-    assert PlayerMinimax.move(@minimax, board) == 8
+    assert Player.choose_move(@minimax, board) == 8
   end
 
   test "move blocks opponent from a win" do
@@ -45,7 +45,7 @@ defmodule PlayerMinimaxTest do
       |> Board.update(6, "O")
       |> Board.update(8, "O")
 
-    assert PlayerMinimax.move(@minimax, board) == 7
+    assert Player.choose_move(@minimax, board) == 7
   end
 
   test "move plays for closest win" do
@@ -55,6 +55,6 @@ defmodule PlayerMinimaxTest do
       |> Board.update(1, "X")
       |> Board.update(8, "X")
 
-    assert PlayerMinimax.move(@minimax, board) == 2
+    assert Player.choose_move(@minimax, board) == 2
   end
 end

--- a/test/player_minimax_test.exs
+++ b/test/player_minimax_test.exs
@@ -1,5 +1,7 @@
 defmodule PlayerMinimaxTest do
   use ExUnit.Case
+  @player_cross "X"
+  @player_nought "O"
 
   test "returns :error if game is over" do
     game_state =
@@ -7,9 +9,8 @@ defmodule PlayerMinimaxTest do
       |> Board.update(0, "X")
       |> Board.update(1, "X")
       |> Board.update(2, "X")
-      |> GameState.new(:human_vs_minimax)
 
-    assert PlayerMinimax.move(game_state) == :error
+    assert PlayerMinimax.move(game_state, @player_cross, @player_nought) == :error
   end
 
   test "move plays for a horizontal win" do
@@ -17,9 +18,8 @@ defmodule PlayerMinimaxTest do
       Board.new()
       |> Board.update(0, "X")
       |> Board.update(1, "X")
-      |> GameState.new(:human_vs_minimax)
 
-    assert PlayerMinimax.move(game_state) == 2
+    assert PlayerMinimax.move(game_state, @player_cross, @player_nought) == 2
   end
 
   test "move plays for a vertical win" do
@@ -27,9 +27,8 @@ defmodule PlayerMinimaxTest do
       Board.new()
       |> Board.update(0, "X")
       |> Board.update(3, "X")
-      |> GameState.new(:human_vs_minimax)
 
-    assert PlayerMinimax.move(game_state) == 6
+    assert PlayerMinimax.move(game_state, @player_cross, @player_nought) == 6
   end
 
   test "move plays for a diagonal win" do
@@ -37,9 +36,8 @@ defmodule PlayerMinimaxTest do
       Board.new()
       |> Board.update(0, "X")
       |> Board.update(4, "X")
-      |> GameState.new(:human_vs_minimax)
 
-    assert PlayerMinimax.move(game_state) == 8
+    assert PlayerMinimax.move(game_state, @player_cross, @player_nought) == 8
   end
 
   test "move blocks opponent from a win" do
@@ -47,9 +45,8 @@ defmodule PlayerMinimaxTest do
       Board.new()
       |> Board.update(6, "O")
       |> Board.update(8, "O")
-      |> GameState.new(:human_vs_minimax)
 
-    assert PlayerMinimax.move(game_state) == 7
+    assert PlayerMinimax.move(game_state, @player_cross, @player_nought) == 7
   end
 
   test "move plays for closest win" do
@@ -58,8 +55,7 @@ defmodule PlayerMinimaxTest do
       |> Board.update(0, "X")
       |> Board.update(1, "X")
       |> Board.update(8, "X")
-      |> GameState.new(:human_vs_minimax)
 
-    assert PlayerMinimax.move(game_state) == 2
+    assert PlayerMinimax.move(game_state, @player_cross, @player_nought) == 2
   end
 end

--- a/test/player_minimax_test.exs
+++ b/test/player_minimax_test.exs
@@ -1,61 +1,60 @@
 defmodule PlayerMinimaxTest do
   use ExUnit.Case
-  @player_cross "X"
-  @player_nought "O"
+  @minimax PlayerMinimax.new("X", "O")
 
   test "returns :error if game is over" do
-    game_state =
+    board =
       Board.new()
       |> Board.update(0, "X")
       |> Board.update(1, "X")
       |> Board.update(2, "X")
 
-    assert PlayerMinimax.move(game_state, @player_cross, @player_nought) == :error
+    assert PlayerMinimax.move(@minimax, board) == :error
   end
 
   test "move plays for a horizontal win" do
-    game_state =
+    board =
       Board.new()
       |> Board.update(0, "X")
       |> Board.update(1, "X")
 
-    assert PlayerMinimax.move(game_state, @player_cross, @player_nought) == 2
+    assert PlayerMinimax.move(@minimax, board) == 2
   end
 
   test "move plays for a vertical win" do
-    game_state =
+    board =
       Board.new()
       |> Board.update(0, "X")
       |> Board.update(3, "X")
 
-    assert PlayerMinimax.move(game_state, @player_cross, @player_nought) == 6
+    assert PlayerMinimax.move(@minimax, board) == 6
   end
 
   test "move plays for a diagonal win" do
-    game_state =
+    board =
       Board.new()
       |> Board.update(0, "X")
       |> Board.update(4, "X")
 
-    assert PlayerMinimax.move(game_state, @player_cross, @player_nought) == 8
+    assert PlayerMinimax.move(@minimax, board) == 8
   end
 
   test "move blocks opponent from a win" do
-    game_state =
+    board =
       Board.new()
       |> Board.update(6, "O")
       |> Board.update(8, "O")
 
-    assert PlayerMinimax.move(game_state, @player_cross, @player_nought) == 7
+    assert PlayerMinimax.move(@minimax, board) == 7
   end
 
   test "move plays for closest win" do
-    game_state =
+    board =
       Board.new()
       |> Board.update(0, "X")
       |> Board.update(1, "X")
       |> Board.update(8, "X")
 
-    assert PlayerMinimax.move(game_state, @player_cross, @player_nought) == 2
+    assert PlayerMinimax.move(@minimax, board) == 2
   end
 end

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -13,10 +13,8 @@ defmodule TicTacToeTest do
       board: Board.new(),
       board_manager: Board,
       ui: UI,
-      io: TicTacToe.Io,
       in: fn -> TicTacToe.Io.get_position(device) end,
       out: fn message -> TicTacToe.Io.output(device, message) end,
-      device: device,
       players:
         Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
     }
@@ -32,10 +30,8 @@ defmodule TicTacToeTest do
       board: Board.new(),
       board_manager: Board,
       ui: UI,
-      io: TicTacToe.Io,
       in: fn -> TicTacToe.Io.get_position(device) end,
       out: fn message -> TicTacToe.Io.output(device, message) end,
-      device: device,
       players:
         Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
     }
@@ -51,10 +47,8 @@ defmodule TicTacToeTest do
       board: Board.new(),
       board_manager: Board,
       ui: UI,
-      io: TicTacToe.Io,
       in: fn -> TicTacToe.Io.get_position(device) end,
       out: fn message -> TicTacToe.Io.output(device, message) end,
-      device: device,
       players:
         Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
     }

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -2,23 +2,11 @@ defmodule TicTacToeTest do
   use ExUnit.Case
   doctest TicTacToe
 
-  @player_cross "X"
-  @player_nought "O"
-
   test "game ends if player cross wins" do
     input_player_cross_win = "1\n7\n2\n8\n3"
     {:ok, device} = StringIO.open(input_player_cross_win)
 
-    args = %Game{
-      board: Board.new(),
-      board_manager: Board,
-      ui: UI,
-      in: fn -> TicTacToe.Io.get_position(device) end,
-      out: fn message -> TicTacToe.Io.output(device, message) end,
-      players:
-        Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
-    }
-
+    args = Game.new(:human_vs_human, device)
     assert TicTacToe.start(args) == :won
   end
 
@@ -26,16 +14,7 @@ defmodule TicTacToeTest do
     input_player_nought_win = "1\n3\n2\n5\n4\n7"
     {:ok, device} = StringIO.open(input_player_nought_win)
 
-    args = %Game{
-      board: Board.new(),
-      board_manager: Board,
-      ui: UI,
-      in: fn -> TicTacToe.Io.get_position(device) end,
-      out: fn message -> TicTacToe.Io.output(device, message) end,
-      players:
-        Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
-    }
-
+    args = Game.new(:human_vs_human, device)
     assert TicTacToe.start(args) == :won
   end
 
@@ -43,16 +22,7 @@ defmodule TicTacToeTest do
     input_players_draw = "1\n2\n5\n9\n6\n4\n7\n3\n8"
     {:ok, device} = StringIO.open(input_players_draw)
 
-    args = %Game{
-      board: Board.new(),
-      board_manager: Board,
-      ui: UI,
-      in: fn -> TicTacToe.Io.get_position(device) end,
-      out: fn message -> TicTacToe.Io.output(device, message) end,
-      players:
-        Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
-    }
-
+    args = Game.new(:human_vs_human, device)
     assert TicTacToe.start(args) == :drawn
   end
 end

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -6,7 +6,7 @@ defmodule TicTacToeTest do
     input_player_cross_win = "1\n7\n2\n8\n3"
     {:ok, device} = StringIO.open(input_player_cross_win)
 
-    args = Game.new(:human_vs_human, device)
+    args = Args.new(:human_vs_human, device)
     assert TicTacToe.start(args) == :won
   end
 
@@ -14,7 +14,7 @@ defmodule TicTacToeTest do
     input_player_nought_win = "1\n3\n2\n5\n4\n7"
     {:ok, device} = StringIO.open(input_player_nought_win)
 
-    args = Game.new(:human_vs_human, device)
+    args = Args.new(:human_vs_human, device)
     assert TicTacToe.start(args) == :won
   end
 
@@ -22,7 +22,7 @@ defmodule TicTacToeTest do
     input_players_draw = "1\n2\n5\n9\n6\n4\n7\n3\n8"
     {:ok, device} = StringIO.open(input_players_draw)
 
-    args = Game.new(:human_vs_human, device)
+    args = Args.new(:human_vs_human, device)
     assert TicTacToe.start(args) == :drawn
   end
 end

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -20,7 +20,7 @@ defmodule TicTacToeTest do
         Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
     }
 
-    assert TicTacToe.start(args) == :ok
+    assert TicTacToe.start(args) == :won
   end
 
   test "game ends if player nought wins" do
@@ -38,7 +38,7 @@ defmodule TicTacToeTest do
         Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
     }
 
-    assert TicTacToe.start(args) == :ok
+    assert TicTacToe.start(args) == :won
   end
 
   test "game ends on draw" do
@@ -56,6 +56,6 @@ defmodule TicTacToeTest do
         Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
     }
 
-    assert TicTacToe.start(args) == :ok
+    assert TicTacToe.start(args) == :drawn
   end
 end

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -1,12 +1,16 @@
 defmodule TicTacToeTest do
   use ExUnit.Case
   doctest TicTacToe
+  alias TicTacToe.Players
 
   test "game ends if player cross wins" do
     input_player_cross_win = "1\n7\n2\n8\n3"
     {:ok, device} = StringIO.open(input_player_cross_win)
 
-    args = Args.new(:human_vs_human, device)
+    display = DisplayState.new(TicTacToe.Io, UI, device)
+    players = [{"X", Players.create(:human, display)}, {"O", Players.create(:human, display)}]
+    game = GameState.new(players)
+    args = Args.new(display, game)
     assert TicTacToe.start(args) == :won
   end
 

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -2,45 +2,60 @@ defmodule TicTacToeTest do
   use ExUnit.Case
   doctest TicTacToe
 
+  @player_cross "X"
+  @player_nought "O"
+
   test "game ends if player cross wins" do
     input_player_cross_win = "1\n7\n2\n8\n3"
     {:ok, device} = StringIO.open(input_player_cross_win)
 
-    args = %{
-      board: Board,
+    args = %Game{
+      board: Board.new(),
+      board_manager: Board,
       ui: UI,
       io: TicTacToe.Io,
-      players: TicTacToe.Players.create(:human_vs_human)
+      out: nil,
+      device: device,
+      players:
+        Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
     }
 
-    assert TicTacToe.start(args, device) == :ok
+    assert TicTacToe.start(args) == :ok
   end
 
   test "game ends if player nought wins" do
     input_player_nought_win = "1\n3\n2\n5\n4\n7"
     {:ok, device} = StringIO.open(input_player_nought_win)
 
-    args = %{
-      board: Board,
+    args = %Game{
+      board: Board.new(),
+      board_manager: Board,
       ui: UI,
       io: TicTacToe.Io,
-      players: TicTacToe.Players.create(:human_vs_human)
+      out: nil,
+      device: device,
+      players:
+        Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
     }
 
-    assert TicTacToe.start(args, device) == :ok
+    assert TicTacToe.start(args) == :ok
   end
 
   test "game ends on draw" do
     input_players_draw = "1\n2\n5\n9\n6\n4\n7\n3\n8"
     {:ok, device} = StringIO.open(input_players_draw)
 
-    args = %{
-      board: Board,
+    args = %Game{
+      board: Board.new(),
+      board_manager: Board,
       ui: UI,
       io: TicTacToe.Io,
-      players: TicTacToe.Players.create(:human_vs_human)
+      out: nil,
+      device: device,
+      players:
+        Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
     }
 
-    assert TicTacToe.start(args, device) == :ok
+    assert TicTacToe.start(args) == :ok
   end
 end

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -14,7 +14,8 @@ defmodule TicTacToeTest do
       board_manager: Board,
       ui: UI,
       io: TicTacToe.Io,
-      out: nil,
+      in: fn -> TicTacToe.Io.get_position(device) end,
+      out: fn message -> TicTacToe.Io.output(device, message) end,
       device: device,
       players:
         Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
@@ -32,7 +33,8 @@ defmodule TicTacToeTest do
       board_manager: Board,
       ui: UI,
       io: TicTacToe.Io,
-      out: nil,
+      in: fn -> TicTacToe.Io.get_position(device) end,
+      out: fn message -> TicTacToe.Io.output(device, message) end,
       device: device,
       players:
         Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))
@@ -50,7 +52,8 @@ defmodule TicTacToeTest do
       board_manager: Board,
       ui: UI,
       io: TicTacToe.Io,
-      out: nil,
+      in: fn -> TicTacToe.Io.get_position(device) end,
+      out: fn message -> TicTacToe.Io.output(device, message) end,
       device: device,
       players:
         Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(:human_vs_human))

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -25,4 +25,10 @@ defmodule TicTacToeTest do
     args = Args.new(:human_vs_human, device)
     assert TicTacToe.start(args) == :drawn
   end
+
+  test "minimax vs minimax ends on draw" do
+    {:ok, device} = StringIO.open("")
+    args = Args.new(:minimax_vs_minimax, device)
+    assert TicTacToe.start(args) == :drawn
+  end
 end

--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -1,16 +1,12 @@
 defmodule TicTacToeTest do
   use ExUnit.Case
   doctest TicTacToe
-  alias TicTacToe.Players
 
   test "game ends if player cross wins" do
     input_player_cross_win = "1\n7\n2\n8\n3"
     {:ok, device} = StringIO.open(input_player_cross_win)
 
-    display = DisplayState.new(TicTacToe.Io, UI, device)
-    players = [{"X", Players.create(:human, display)}, {"O", Players.create(:human, display)}]
-    game = GameState.new(players)
-    args = Args.new(display, game)
+    args = Args.new(:human_vs_human, device)
     assert TicTacToe.start(args) == :won
   end
 


### PR DESCRIPTION
This PR is a chunky monkey of refactoring that sets the stage for future features by adding ✨ structs, protocols and polymorphism ✨ which are still pretty heavy concepts for me right now. Unfortunately that means this PR spans across thirteen files, so is a bit of a whopper. 

- `Args`, `DisplayState`, `GameState` are the main structs.
- `Players` serves as a factory for each game mode. 
- `Player` is our protocol, which creates a `choose_move` function signature for `PlayerMinimax` and `PlayerHuman` to implement.

Some more conceptual questions I still have, thoughts welcome 🤔 

- We've got polymophic protocol implementations for PlayerMinimax, now we've got different requirements for PlayerMinimax and PlayerHuman's respective `new` functions - the former takes two args, each mark, and the latter takes various IO functions. What's the *elegant* way to set that up in our factory? Right now we're matching on a game mode atom (e.g. `:human_vs_human` or `:minimax_vs_minimax`) but now there's additional reqs.
1. Bite the bullet and make a `case` expression instead of tiny pattern matched functions with 1 arity.
2. The the functions to an arity of 2 and kitchen sink the full `%Args{}` into each of them, then let them sort it out. 

- Any thoughts on where to put the `defimpl` code? The Elixir source both spreads its implementations for `Enumerable` out into separate files but consolidates into one file for `String.Chars` - probably because the latter is a much tinier implementation, so I'd probably suggest that the `Player` code does the same. 

- The `PlayerHuman` struct essentially requires the `DisplayState` struct in its entirety. Right now I've basically cloned the struct from one to the other, so we're not going more than 1 `.` deep in our calls, but I wonder if that's.... the right thing to do? Is it inefficient? Un-idiomatic? Much thought. 