### PR TITLE
Add clarity to TicTacToe game loop with named functions

### DIFF
--- a/lib/tic_tac_toe.ex
+++ b/lib/tic_tac_toe.ex
@@ -9,43 +9,43 @@ defmodule TicTacToe do
     [display.ui.message(:title), display.ui.message(:intro)]
     |> display.out.()
 
-    next(:active, args)
+    next_turn(args)
   end
 
-  defp next(:active, %Args{game: game, display: display} = args) do
+  defp next_turn(%Args{game: game, display: display} = args) do
     [
       display.ui.draw_board(game.board),
       display.ui.player_turn(Players.current_mark(game.players))
     ]
     |> display.out.()
 
-    pos =
+    position =
       Players.current_player(game.players)
       |> Player.choose_move(game.board)
 
-    updated_board = Board.update(game.board, pos, Players.current_mark(game.players))
+    updated_board = Board.update(game.board, position, Players.current_mark(game.players))
 
     Board.status(updated_board)
     |> case do
       :won ->
-        next(:won, Args.update_board(args, updated_board))
+        won(Args.update_board(args, updated_board))
 
       :drawn ->
-        next(:drawn, Args.update_board(args, updated_board))
+        drawn(Args.update_board(args, updated_board))
 
       :active ->
-        next(:active, Args.update_board(args, updated_board) |> Args.update_players())
+        next_turn(Args.update_board(args, updated_board) |> Args.update_players())
     end
   end
 
-  defp next(:drawn, %Args{game: game, display: display}) do
+  defp drawn(%Args{game: game, display: display}) do
     [display.ui.draw_board(game.board), display.ui.draw()]
     |> display.out.()
 
     :drawn
   end
 
-  defp next(:won, %Args{game: game, display: display}) do
+  defp won(%Args{game: game, display: display}) do
     mark = Players.current_mark(game.players)
 
     [display.ui.draw_board(game.board), display.ui.winner(mark)]


### PR DESCRIPTION
This PR is a slight refactor to add clarity to the codebase: it replaces a recursive function that pattern matches on atoms (pattern matching on atoms is awesome and super fun) with clearer named functions. 