### PR TITLE
Tidy Elixir module names to adhere to Elixir naming conventions

### DIFF
--- a/lib/UI.ex
+++ b/lib/UI.ex
@@ -1,4 +1,4 @@
-defmodule UI do
+defmodule Ui do
   def draw_board(%Board{} = board) do
     board
     |> calculate_board_rows()

--- a/lib/args.ex
+++ b/lib/args.ex
@@ -2,7 +2,7 @@ defmodule Args do
   defstruct [:game, :display]
 
   def new(mode, device \\ :stdio) do
-    display = DisplayState.new(TicTacToe.Io, UI, device)
+    display = DisplayState.new(TicTacToe.Io, Ui, device)
 
     %Args{
       game: GameState.new(mode, display),

--- a/test/UI_test.exs
+++ b/test/UI_test.exs
@@ -1,10 +1,10 @@
-defmodule UITest do
+defmodule UiTest do
   use ExUnit.Case
 
   @full_3x3_board_string "+-----------+\n| X | O | O |\n+-----------+\n| O | X | X |\n+-----------+\n| X | X | O |\n+-----------+\n"
   @empty_4x4_board_string "+-------------------+\n| \e[38;5;242m01\e[0m | \e[38;5;242m02\e[0m | \e[38;5;242m03\e[0m | \e[38;5;242m04\e[0m |\n+-------------------+\n| \e[38;5;242m05\e[0m | \e[38;5;242m06\e[0m | \e[38;5;242m07\e[0m | \e[38;5;242m08\e[0m |\n+-------------------+\n| \e[38;5;242m09\e[0m | \e[38;5;242m10\e[0m | \e[38;5;242m11\e[0m | \e[38;5;242m12\e[0m |\n+-------------------+\n| \e[38;5;242m13\e[0m | \e[38;5;242m14\e[0m | \e[38;5;242m15\e[0m | \e[38;5;242m16\e[0m |\n+-------------------+\n"
 
-  test "UI.draw_board/1 should output current game state" do
+  test "Ui.draw_board/1 should output current game state" do
     board =
       Board.new()
       |> Board.update(0, "X")
@@ -17,12 +17,12 @@ defmodule UITest do
       |> Board.update(7, "X")
       |> Board.update(8, "O")
 
-    assert UI.draw_board(board) == @full_3x3_board_string
+    assert Ui.draw_board(board) == @full_3x3_board_string
   end
 
-  test "UI.draw_board/1 can output a 4x4 board" do
+  test "Ui.draw_board/1 can output a 4x4 board" do
     board = Board.new(:four_by_four)
 
-    assert UI.draw_board(board) == @empty_4x4_board_string
+    assert Ui.draw_board(board) == @empty_4x4_board_string
   end
 end

--- a/test/player_human_test.exs
+++ b/test/player_human_test.exs
@@ -7,7 +7,7 @@ defmodule PlayerHumanTest do
     {:ok, io} = StringIO.open("1")
 
     player =
-      DisplayState.new(TicTacToe.Io, UI, io)
+      DisplayState.new(TicTacToe.Io, Ui, io)
       |> PlayerHuman.new()
 
     assert Player.choose_move(player, Board.new()) == 0
@@ -17,7 +17,7 @@ defmodule PlayerHumanTest do
     {:ok, io} = StringIO.open("cat\n1")
 
     player =
-      DisplayState.new(TicTacToe.Io, UI, io)
+      DisplayState.new(TicTacToe.Io, Ui, io)
       |> PlayerHuman.new()
 
     assert Player.choose_move(player, Board.new()) == 0


### PR DESCRIPTION
Another very slight change: renames Board.ex to board.ex and UI.ex to Ui.ex 👍 