### PR TITLE
Add game menu

### DIFF
--- a/lib/UI.ex
+++ b/lib/UI.ex
@@ -75,6 +75,12 @@ defmodule UI do
       :title ->
         "TIC TAC TOE"
 
+      :choose_mode ->
+        "Select your mode:\n1. HUMAN vs HUMAN\n2. HUMAN vs ALGORITHM\n3. ALGORITHM vs ALGORITHM\n"
+
+      :choose_board ->
+        "Select your board size:\n1. THREE by THREE\n2. FOUR by FOUR\n"
+
       :intro ->
         "Turn friends into enemies by succeeding in placing a complete line in any horizontal, vertical or diagonal direction"
 

--- a/lib/args.ex
+++ b/lib/args.ex
@@ -1,6 +1,13 @@
 defmodule Args do
   defstruct [:game, :display]
 
+  def build(%GameState{} = game, %DisplayState{} = display) do
+    %Args{
+      game: game,
+      display: display
+    }
+  end
+
   def new(mode, device \\ :stdio) do
     display = DisplayState.new(TicTacToe.Io, UI, device)
 

--- a/lib/args.ex
+++ b/lib/args.ex
@@ -1,7 +1,7 @@
 defmodule Args do
   defstruct [:game, :display]
 
-  def build(%GameState{} = game, %DisplayState{} = display) do
+  def new_from_state(%GameState{} = game, %DisplayState{} = display) do
     %Args{
       game: game,
       display: display

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -6,7 +6,18 @@ defmodule TicTacToe.CLI do
   """
   @device :stdio
   def main(_) do
-    args = Args.new(:human_vs_human, @device)
+    display = DisplayState.new(TicTacToe.Io, UI, @device)
+    mode = Menu.get_mode(display)
+
+    board_size =
+      if mode == :human_vs_human do
+        Menu.get_board_size(display)
+      else
+        :three_by_three
+      end
+
+    game = GameState.new(mode, board_size, display)
+    args = Args.build(game, display)
     TicTacToe.start(args)
   end
 end

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -7,17 +7,20 @@ defmodule TicTacToe.CLI do
   @device :stdio
   def main(_) do
     display = DisplayState.new(TicTacToe.Io, UI, @device)
-    mode = Menu.get_mode(display)
-
-    board_size =
-      if mode == :human_vs_human do
-        Menu.get_board_size(display)
-      else
-        :three_by_three
-      end
-
+    {mode, board_size} = setup(display)
     game = GameState.new(mode, board_size, display)
-    args = Args.build(game, display)
+    args = Args.new_from_state(game, display)
+
     TicTacToe.start(args)
   end
+
+  defp setup(display) do
+    mode = Menu.get_mode(display)
+    board_size = get_board_size(mode, display)
+
+    {mode, board_size}
+  end
+
+  defp get_board_size(:human_vs_human, display), do: Menu.get_board_size(display)
+  defp get_board_size(_, _), do: :three_by_three
 end

--- a/lib/display_state.ex
+++ b/lib/display_state.ex
@@ -1,5 +1,5 @@
 defmodule DisplayState do
-  defstruct [:io, :device, :ui, :in, :out]
+  defstruct [:ui, :in, :out]
 
   def new(io, ui, device) do
     %DisplayState{

--- a/lib/game_state.ex
+++ b/lib/game_state.ex
@@ -5,11 +5,11 @@ defmodule GameState do
 
   alias TicTacToe.Players
 
-  def new(player_mode, opts) do
+  def new(player_mode, board_size \\ :three_by_three, display) do
     %GameState{
-      board: Board.new(),
+      board: Board.new(board_size),
       players:
-        Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(player_mode, opts))
+        Enum.zip([@player_cross, @player_nought], TicTacToe.Players.create(player_mode, display))
     }
   end
 
@@ -21,4 +21,3 @@ defmodule GameState do
     %GameState{game | players: Players.next_turn(game.players)}
   end
 end
-

--- a/lib/menu.ex
+++ b/lib/menu.ex
@@ -1,0 +1,58 @@
+defmodule Menu do
+  def get_mode(message \\ :choose_mode, %DisplayState{out: out, in: input, ui: ui} = display) do
+    out.(ui.message(message))
+
+    input.()
+    |> coerce_int()
+    |> validate_mode()
+    |> case do
+      {:error, error} -> get_mode(error, display)
+      mode -> mode
+    end
+  end
+
+  def get_board_size(
+        message \\ :choose_board,
+        %DisplayState{out: out, in: input, ui: ui} = display
+      ) do
+    out.(ui.message(message))
+
+    input.()
+    |> coerce_int()
+    |> validate_board()
+    |> case do
+      {:error, error} -> get_board_size(error, display)
+      board_size -> board_size
+    end
+  end
+
+  defp validate_mode(mode_number) do
+    case mode_number do
+      1 -> :human_vs_human
+      2 -> :human_vs_minimax
+      3 -> :minimax_vs_minimax
+      x when not is_integer(x) -> {:error, :nan}
+      x when x < 1 or x > 3 -> {:error, :out_of_bounds}
+      _ -> {:error, :unknown}
+    end
+  end
+
+  defp validate_board(mode_number) do
+    case mode_number do
+      1 -> :three_by_three
+      2 -> :four_by_four
+      x when not is_integer(x) -> {:error, :nan}
+      x when x < 1 or x > 2 -> {:error, :out_of_bounds}
+      _ -> {:error, :unknown}
+    end
+  end
+
+  defp coerce_int(string) do
+    string
+    |> Integer.parse()
+    |> case do
+      {int, _} -> int
+      _ -> string
+    end
+  end
+end

--- a/lib/players.ex
+++ b/lib/players.ex
@@ -7,6 +7,10 @@ defmodule TicTacToe.Players do
     [PlayerHuman.new(display), PlayerHuman.new(display)]
   end
 
+  def create(:human_vs_minimax, %DisplayState{} = display) do
+    [PlayerHuman.new(display), PlayerMinimax.new("O", "X")]
+  end
+
   def create(:minimax_vs_minimax, _) do
     [PlayerMinimax.new("X", "O"), PlayerMinimax.new("O", "X")]
   end

--- a/test/menu_test.exs
+++ b/test/menu_test.exs
@@ -1,0 +1,56 @@
+defmodule MenuTest do
+  use ExUnit.Case
+
+  describe "Menu.get_mode/2" do
+    test "returns atom for human vs human if input is 1" do
+      {:ok, io} = StringIO.open("1")
+      display = DisplayState.new(TicTacToe.Io, UI, io)
+
+      assert Menu.get_mode(display) == :human_vs_human
+    end
+
+    test "returns atom for human vs minimax if input is 2" do
+      {:ok, io} = StringIO.open("2")
+      display = DisplayState.new(TicTacToe.Io, UI, io)
+
+      assert Menu.get_mode(display) == :human_vs_minimax
+    end
+
+    test "returns atom for minimax vs minimax if input is 3" do
+      {:ok, io} = StringIO.open("3")
+      display = DisplayState.new(TicTacToe.Io, UI, io)
+
+      assert Menu.get_mode(display) == :minimax_vs_minimax
+    end
+
+    test "returns makes user re-enter input until correct mode number is provided" do
+      {:ok, io} = StringIO.open("-15\ncat\nhorse\n205\n1")
+      display = DisplayState.new(TicTacToe.Io, UI, io)
+
+      assert Menu.get_mode(display) == :human_vs_human
+    end
+  end
+
+  describe "Menu.get_board/2" do
+    test "returns atom for three by three if input is 1" do
+      {:ok, io} = StringIO.open("1")
+      display = DisplayState.new(TicTacToe.Io, UI, io)
+
+      assert Menu.get_board_size(display) == :three_by_three
+    end
+
+    test "returns atom for four by four if input is 2" do
+      {:ok, io} = StringIO.open("2")
+      display = DisplayState.new(TicTacToe.Io, UI, io)
+
+      assert Menu.get_board_size(display) == :four_by_four
+    end
+
+    test "returns makes user re-enter input until correct mode number is provided" do
+      {:ok, io} = StringIO.open("-15\ncat\nhorse\n205\n3\n1")
+      display = DisplayState.new(TicTacToe.Io, UI, io)
+
+      assert Menu.get_board_size(display) == :three_by_three
+    end
+  end
+end


### PR DESCRIPTION
This adds a CLI menu for the player to select their game mode and board size.

As minimax is tragically unoptimised in its current state, there is currently some logic to stop the player from choosing a board size if minimax is involved - choosing the algorithm will auto-set a 3x3 board. 

The code here, to me, exposes that UI/IO can be separated and that all CLI-based functions could be extacted via protocols in a future refactor/feature/sprint. 